### PR TITLE
CASMTRIAGE-1834 : Disable PDB in the postgres operator and let the au…

### DIFF
--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -72,6 +72,7 @@ postgres-operator:
     pod_environment_configmap: "postgres-nodes-pod-env"
     spilo_fsgroup: 103
     update_strategy_type: "RollingUpdate"
+    enable_pod_disruption_budget: false
 
   # configure behavior of load balancers
   configLoadBalancer:


### PR DESCRIPTION
## Summary and Scope
CASMTRIAGE-1834
*  Disable PDB in the postgres operator and let the automatic failover handle this when the node drains

## Issues and Related PRs
docs-csm will also be updated as part of CASMTRIAGE-1834 to 
* provide a script (docs-csm/upgrade/1.0/scripts/k8s/failover_leader.sh) to failover a postgres leader if running on a worker that is to be drained
* provide doc updates to the (docs-csm/upgrade/1.0/README.md) to indicate that the script should be run before the worker is drained

## Testing

prior to the change - the postgres pod disruption budget was
```
$ kubectl get poddisruptionbudgets.policy -A | grep postgres
NAMESPACE      NAME                                      MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
services       postgres-cray-console-data-postgres-pdb   0               N/A               1                     55s
services       postgres-cray-sls-postgres-pdb            0               N/A               1                     55s
services       postgres-cray-smd-postgres-pdb            0               N/A               1                     55s
services       postgres-gitea-vcs-postgres-pdb           0               N/A               1                     58s
services       postgres-keycloak-postgres-pdb            0               N/A               1                     58s
spire          postgres-spire-postgres-pdb               0               N/A               1                     54s
```
after the upgrade and a restart of the postgres operator
```
$ kubectl delete pod  -l app.kubernetes.io/name=postgres-operator -n services

$ kubectl logs cray-postgres-operator-6fffc48b4c-l6wfr -n services -c postgres-operator -f | grep disruption
time="2021-08-03T18:02:55Z" level=debug msg="syncing pod disruption budgets" cluster-name=services/gitea-vcs-postgres pkg=cluster
time="2021-08-03T18:02:55Z" level=info msg="pod disruption budget \"services/postgres-gitea-vcs-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=services/gitea-vcs-postgres pkg=cluster
time="2021-08-03T18:02:55Z" level=debug msg="deleting pod disruption budget" cluster-name=services/gitea-vcs-postgres pkg=cluster
time="2021-08-03T18:02:55Z" level=info msg="pod disruption budget \"services/postgres-gitea-vcs-postgres-pdb\" has been deleted" cluster-name=services/gitea-vcs-postgres pkg=cluster
time="2021-08-03T18:02:57Z" level=debug msg="syncing pod disruption budgets" cluster-name=services/keycloak-postgres pkg=cluster
time="2021-08-03T18:02:57Z" level=info msg="pod disruption budget \"services/postgres-keycloak-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=services/keycloak-postgres pkg=cluster
time="2021-08-03T18:02:57Z" level=debug msg="deleting pod disruption budget" cluster-name=services/keycloak-postgres pkg=cluster
time="2021-08-03T18:02:57Z" level=info msg="pod disruption budget \"services/postgres-keycloak-postgres-pdb\" has been deleted" cluster-name=services/keycloak-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="syncing pod disruption budgets" cluster-name=services/cray-smd-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-smd-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=services/cray-smd-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="deleting pod disruption budget" cluster-name=services/cray-smd-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-smd-postgres-pdb\" has been deleted" cluster-name=services/cray-smd-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="syncing pod disruption budgets" cluster-name=services/cray-sls-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-sls-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=services/cray-sls-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="deleting pod disruption budget" cluster-name=services/cray-sls-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-sls-postgres-pdb\" has been deleted" cluster-name=services/cray-sls-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="syncing pod disruption budgets" cluster-name=services/cray-console-data-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-console-data-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=services/cray-console-data-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=debug msg="deleting pod disruption budget" cluster-name=services/cray-console-data-postgres pkg=cluster
time="2021-08-03T18:02:59Z" level=info msg="pod disruption budget \"services/postgres-cray-console-data-postgres-pdb\" has been deleted" cluster-name=services/cray-console-data-postgres pkg=cluster
time="2021-08-03T18:03:00Z" level=debug msg="syncing pod disruption budgets" cluster-name=spire/spire-postgres pkg=cluster
time="2021-08-03T18:03:00Z" level=info msg="pod disruption budget \"spire/postgres-spire-postgres-pdb\" is not in the desired state and needs to be updated" cluster-name=spire/spire-postgres pkg=cluster
time="2021-08-03T18:03:00Z" level=debug msg="deleting pod disruption budget" cluster-name=spire/spire-postgres pkg=cluster
time="2021-08-03T18:03:00Z" level=info msg="pod disruption budget \"spire/postgres-spire-postgres-pdb\" has been deleted" cluster-name=spire/spire-postgres pkg=cluster


$ kubectl get poddisruptionbudgets.policy -A  | grep postgres                                                                                                                      
NAMESPACE      NAME                                      MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
services       postgres-cray-console-data-postgres-pdb   0               N/A               1                     50s
services       postgres-cray-sls-postgres-pdb            0               N/A               1                     50s
services       postgres-cray-smd-postgres-pdb            0               N/A               1                     50s
services       postgres-gitea-vcs-postgres-pdb           0               N/A               1                     54s
services       postgres-keycloak-postgres-pdb            0               N/A               1                     52s
spire          postgres-spire-postgres-pdb               0               N/A               1                     49s
```

Before the change, when draining a worker that had a postgres master pod running on it - the drain fails with
```
error when evicting pod "cray-sls-postgres-0" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```

After the change, when draining a worker that had a postgres master pod running on it - the drain succeeds with
```
pod/cray-sls-postgres-2 evicted
```

## Tested on:
 vShasta
Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) NA
Was a fresh Install tested? Y/N If not, Why? Y
Was an Upgrade tested? Y/N If not, Why? Y
Was a Downgrade tested? Y/N. If not, Why? Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? NA

## Risks and Mitigations
Requires:
* Restart of the postgres-operator for the change to take effect