### PR TITLE
CASMPET-4612: Release cray-postgres-operator for csm-1.0

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -3,7 +3,7 @@
 #
 apiVersion: v2
 name: cray-postgres-operator
-version: 0.11.1
+version: 0.11.2
 appVersion: "852f292" # the postgres-operator repo sha
 home: "cloud/cray-charts"
 description: Cray-specific parent chart of github.com/zalando/postgres-operator


### PR DESCRIPTION
Release cray-postgres-operator 
Targeted for csm-1.0
Adds CASMTRAIGE-1834 pod disruption budget change