### PR TITLE
CASMPET-5567: add image annotations

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 0.13.0
+version: 0.14.0
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -35,6 +35,13 @@ dependencies:
     version: 1.6.0
 maintainers:
   - name: kimjensen-hpe
-appVersion: "2.2.0"  # the postgres-operator image version
+appVersion: "2.3.0"  # the postgres-operator image version
 annotations:
   artifacthub.io/license: MIT
+  artifacthub.io/images: |
+    - name: postgres-operator
+      image: artifactory.algol60.net/csm-docker/stable/postgres-operator:2.3.0
+    - name: postgres-exporter
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
+    - name: spilo-12
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/spilo-12:1.6-p3

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -31,7 +31,7 @@ kubectl:
 postgres-operator:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/postgres-operator
-    tag: 2.2.0  # Update the appVersion in Chart.yaml
+    tag: 2.3.0  # Update the appVersion in Chart.yaml
     pullPolicy: "IfNotPresent"
 
   # Deploy "postgres_exporter" as sidecar container to "postgres"


### PR DESCRIPTION
## Summary and Scope

Added image annotations so that the underlying images (e.g., postgres-operator) will be automatically rebuilt. The chart minor version was bumped from 0.13.0 to 0.14.0.

## Issues and Related PRs

* Resolves [CASMPET-5567]

## Testing

### Tested on:

  * `wasp`

### Test description:

Deployed this to wasp and made sure that the right postgres-operator 2.3.0 image was used. Made sure I could run patronictl list. Made sure that restarting the keycloak postgres pods worked. Made sure I could still get a token and use it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

