### PR TITLE
CASMPET-6265 ChCat : Fix helm output for cray-postgres-operator deployment and other minor improvements

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.8.3
+version: 1.8.4
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:

--- a/kubernetes/cray-postgres-operator/templates/NOTES.txt
+++ b/kubernetes/cray-postgres-operator/templates/NOTES.txt
@@ -1,3 +1,3 @@
 To verify that postgres-operator has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "cray-postgres-operator.name" . }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ template "cray-postgres-operator.name" . }}"

--- a/kubernetes/cray-postgres-operator/templates/inject-secret.yaml
+++ b/kubernetes/cray-postgres-operator/templates/inject-secret.yaml
@@ -33,7 +33,7 @@ kind: Job
 metadata:
   name: {{ template "cray-postgres-operator.fullname" . }}-inject-secret
   annotations:
-    helm.sh/hook: post-upgrade,post-upgrade
+    helm.sh/hook: post-upgrade,post-install
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -44,7 +44,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cray-{{ template "cray-postgres-operator.fullname" . }}-jobs-role
+  name: {{ template "cray-postgres-operator.fullname" . }}-jobs-role
 rules:
 - apiGroups: ["", "batch", "apiextensions.k8s.io", "acid.zalan.do"]
   resources: ["customresourcedefinitions", "cronjobs", "secrets", "operatorconfigurations"]
@@ -53,7 +53,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cray-{{ template "cray-postgres-operator.fullname" . }}-jobs-role-binding
+  name: {{ template "cray-postgres-operator.fullname" . }}-jobs-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ template "cray-postgres-operator.fullname" . }}-jobs
@@ -61,4 +61,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cray-{{ template "cray-postgres-operator.fullname" . }}-jobs-role
+  name: {{ template "cray-postgres-operator.fullname" . }}-jobs-role


### PR DESCRIPTION
## Summary and Scope

Few minor improvements - for Cheshire Cat Release
* correct old issue with helm NOTES
* fix job to include post-install
* change clusterrole and clusterrolebinding to remove extra leading "cray-"

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ bug fix

## Issues and Related PRs

* Resolves [CASMPET-6265](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6265)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

* vshasta v2 - dorian

### Test description:

* Check that NOTES now give the correct command to verify cray-postgres-operator is runnning
```
pit:/tmp # helm upgrade -n services cray-postgres-operator ./cray-postgres-operator-1.8.3-20230124224850+ddd003b.tgz
Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Tue Jan 24 22:51:07 2023
NAMESPACE: services
STATUS: deployed
REVISION: 17
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"

pit:/tmp # kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
NAME                                      READY   STATUS    RESTARTS   AGE
cray-postgres-operator-7b456b7449-xhwll   2/2     Running   0          7d3h
```
* Verify the CR and CRB no longer contain the extra leading "cray-"
```
pit:/tmp # kubectl get clusterrolebinding -A | grep postgres-operator-jobs-role-binding
cray-postgres-operator-jobs-role-binding                       ClusterRole/cray-postgres-operator-jobs-role                                       48m

pit:/tmp # kubectl get clusterrole -A | grep postgres-operator-jobs-role
cray-postgres-operator-jobs-role                                       2023-01-24T22:04:52Z

```
* Verify that the post-install hook is in place and working - TBD during next vshasta v2 Cheshire Cat fresh install.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

