### PR TITLE
CASMPET-6280 ChCat : Add rbac for delete pod for cray-postgres-operator inject-secret job

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.8.4
+version: 1.8.5
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:

--- a/kubernetes/cray-postgres-operator/templates/inject-secret.yaml
+++ b/kubernetes/cray-postgres-operator/templates/inject-secret.yaml
@@ -35,8 +35,9 @@ metadata:
   annotations:
     helm.sh/hook: post-upgrade,post-install
     helm.sh/hook-weight: "-10"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       name: {{ template "cray-postgres-operator.fullname" . }}-inject-secret
@@ -59,11 +60,11 @@ spec:
                echo "Inject postgres-backup-s3-credentials secret into operatorconfiguration..."
                access_key=$(kubectl get secrets postgres-backup-s3-credentials -n services -ojsonpath='{.data.access_key}' | base64 -d)
                secret_key=$(kubectl get secrets postgres-backup-s3-credentials -n services -ojsonpath='{.data.secret_key}' | base64 -d)
-               kubectl patch  operatorconfigurations cray-postgres-operator -n services --type='json' -p='[{"op":"replace", "path":"/configuration/logical_backup/logical_backup_s3_access_key_id", "value":'"${access_key}"'}]' > /dev/null 2>&1
-               kubectl patch  operatorconfigurations cray-postgres-operator -n services --type='json' -p='[{"op":"replace", "path":"/configuration/logical_backup/logical_backup_s3_secret_access_key", "value":'"${secret_key}"'}]' > /dev/null 2>&1
+               kubectl patch  operatorconfigurations cray-postgres-operator -n services --type='json' -p='[{"op":"replace", "path":"/configuration/logical_backup/logical_backup_s3_access_key_id", "value":'"${access_key}"'}]'
+               kubectl patch  operatorconfigurations cray-postgres-operator -n services --type='json' -p='[{"op":"replace", "path":"/configuration/logical_backup/logical_backup_s3_secret_access_key", "value":'"${secret_key}"'}]'
 
                echo "Restart the cray-postgres-operator..."
-               kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services > /dev/null 2>&1
+               kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
 
                echo "Delete any logical backup cronjobs so postgres-operator can recreate them on next sync with updated secrets..."
                while read cjob ns; do kubectl delete cronjob ${cjob} -n ${ns} > /dev/null 2>&1; done < <(kubectl get cronjob --no-headers -A | awk '{print $2" "$1}' | grep "^logical-backup")

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -47,7 +47,7 @@ metadata:
   name: {{ template "cray-postgres-operator.fullname" . }}-jobs-role
 rules:
 - apiGroups: ["", "batch", "apiextensions.k8s.io", "acid.zalan.do"]
-  resources: ["customresourcedefinitions", "cronjobs", "secrets", "operatorconfigurations"]
+  resources: ["customresourcedefinitions", "cronjobs", "secrets", "operatorconfigurations", "pods"]
   verbs: ["get", "list", "delete", "patch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary and Scope

Adds "delete pods" to rbac for the cray-postgres-operator-jobs serviceAccount used to inject secrets.
Also removed "hook-succeeded", added TTL of 24hr and removed ">/dev/null >2&1" to provide more info.

## Issues and Related PRs

* Resolves [CASMPET-6280](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6280)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

  * vshasta v2 - dorian
  
### Test description:

* Verified that the job succeeded
```
# kubectl logs cray-postgres-operator-inject-secret-c2tsh -n services
Inject postgres-backup-s3-credentials secret into operatorconfiguration...
operatorconfiguration.acid.zalan.do/cray-postgres-operator patched
operatorconfiguration.acid.zalan.do/cray-postgres-operator patched
Restart the cray-postgres-operator...
pod "cray-postgres-operator-7b456b7449-gr52m" deleted
Delete any logical backup cronjobs so postgres-operator can recreate them on next sync with updated secrets...
Done!
```

* Verified that the cray-postgres-operator pod was successfully restarted by the helm post-upgrade job

```
# kubectl get pods -A | grep postgres-oper
services         cray-postgres-operator-7b456b7449-xbfgr                           2/2     Running     0          85s
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Very low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

