### PR TITLE
CASMTRIAGE-7120 - Workaround for premature failover when PostgreSQL leader loses contact with kube-apiserver during reboot of control plane nodes

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.8.5
+version: 1.8.6
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:

--- a/kubernetes/cray-postgres-operator/templates/configmaps.yaml
+++ b/kubernetes/cray-postgres-operator/templates/configmaps.yaml
@@ -29,3 +29,4 @@ metadata:
 data:
   DEVELOP: "1"
   SPILO_PROVIDER: "local"
+  PATRONI_KUBERNETES_BYPASS_API_SERVICE: "true"


### PR DESCRIPTION
## Summary and Scope

There appears to be a bug in the version of patroni included in the spilo image we are using in CSM 1.5 and 1.6.

When a control-plane node is rebooted, there is a brief interruption in access to the Kubernetes API. The PostgreSQL leader unfortunately detects this condition and demotes itself resulting in a leadership race.

```
2024-08-19 17:51:21,274 INFO: Lock owner: cray-console-data-postgres-0; I am cray-console-data-postgres-0
2024-08-19 17:51:26,281 ERROR: Request to server https://10.16.0.1:443 failed: ReadTimeoutError("HTTPSConnectionPool(host='10.16.0.1', port=443): Read timed out. (read timeout=4.999643940944225)",)
2024-08-19 17:51:29,178 ERROR: Request to server https://10.16.0.1:443 failed: ReadTimeoutError("HTTPSConnectionPool(host='10.16.0.1', port=443): Read timed out. (read timeout=2.0940666801761836)",)
2024-08-19 17:51:30,672 ERROR: Request to server https://10.16.0.1:443 failed: ReadTimeoutError("HTTPSConnectionPool(host='10.16.0.1', port=443): Read timed out. (read timeout=1)",)
2024-08-19 17:51:30,672 ERROR: failed to update leader lock
2024-08-19 17:51:30,672 INFO: Demoting self (immediate-nolock)
2024-08-19 17:51:33,303 INFO: demoted self because failed to update leader lock in DCS
2024-08-19 17:51:33,305 WARNING: Loop time exceeded, rescheduling immediately.
2024-08-19 17:51:33,308 INFO: closed patroni connection to the postgresql cluster
2024-08-19 17:51:33,635 INFO: postmaster pid=242822
```
When this occurs the database can failover and while the Kubernetes ClusterIP load balancer for each database is updated correctly, the clients never have their connection to the former leader broken so are unaware a failover has occurred and continue to send it transactions resulting in errors like the following.
```
2024/07/03 09:12:20.006580 smd.go:322: SCNSubscriptionRefresh(): Lookup failure: pq: cannot set transaction read-write mode during recovery
```
The older version of the Spilo image used in CSM 1.4 does not behave this way.

A workaround to the problem is to use the `PATRONI_KUBERNETES_BYPASS_API_SERVICE` [environment variable](https://patroni.readthedocs.io/en/latest/ENVIRONMENT.html#kubernetes) which causes Patroni resolve the API nodes behind the `kubernetes` service and uses those rather than relying on the single IP.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7120](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7120)

## Testing

### Tested on:

  * `surtur`
  * `starlord`
  * `gamora`

### Test description:

Tested on surtur by rebooting ncn-m002, the leader registers a temporary loss of access to the `kubernetes` service but does not fail over.
```
2024-08-23 14:41:16.211 UTC [30] LOG {ticks: 0, maint: 0, retry: 0}
2024-08-23 14:41:21,006 INFO: no action. I am (cray-console-data-postgres-0), the leader with the lock
2024-08-23 14:41:29,449 WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=0, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='10.16.0.1', port=443): Read timed out. (read timeout=4.999775651842356)",)': /api/v1/namespaces/services/pods?labelSelector=application%3Dspilo%2Ccluster-name%3Dcray-console-data-postgres
2024-08-23 14:41:30,674 INFO: no action. I am (cray-console-data-postgres-0), the leader with the lock
2024-08-23 14:41:40,676 INFO: no action. I am (cray-console-data-postgres-0), the leader with the lock
2024-08-23 14:41:46.219 UTC [30] LOG {ticks: 0, maint: 0, retry: 0}
```
This was also tested on gamora, all master nodes were rebooted as part of the managed node rollout with no PostgreSQL database oddities noted (issue usually manifests itself by `cray smd ...` or `sat status` commands failing and `cray-console` stops working because `cray-console-data` can't talk to its database).

## Risks and Mitigations

When the ConfigMap is updated, the operator updates the StatefulSet of every PostgreSQL database with the `PATRONI_KUBERNETES_BYPASS_API_SERVICE` environment variable. Simply removing the variable from the ConfigMap reverses the procedure.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

