### PR TITLE
CASMPET-7335 update cray-postgres-operator to version 1.10.1

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.lock
+++ b/kubernetes/cray-postgres-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgres-operator
   repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
-  version: 1.8.2
-digest: sha256:aafa7f43520a408622987ecfdd99825baf6725c2702427ebd09e9cdd304f86e0
-generated: "2022-10-12T16:45:17.679506-06:00"
+  version: 1.10.1
+digest: sha256:65b56e1d61f37876eb59bc6ce77a16887344629c33e047bc216c78b2d92ae974
+generated: "2025-02-06T11:40:14.864051-06:00"

--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.8.5
+version: 1.10.1
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -32,21 +32,21 @@ sources:
   - https://github.com/zalando/postgres-operator
 dependencies:
   - name: postgres-operator
-    version: 1.8.2
+    version: 1.10.1
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 maintainers:
   - name: kimjensen-hpe
-appVersion: "1.8.2"  # the postgres-operator dependent chart version
+appVersion: "1.10.1"  # the postgres-operator dependent chart version
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: postgres-operator
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.8.2
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1
     - name: postgres-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
     - name: spilo-14
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     - name: logical-backup
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.8.2
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1
     - name: pgbouncer
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-22
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-27

--- a/kubernetes/cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml
+++ b/kubernetes/cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml
@@ -1,0 +1,1432 @@
+{{/*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+# The following CRDs are created in CSM 1.7 prerequisites.sh
+# before the cray-postgres-operator upgrade
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: operatorconfigurations.acid.zalan.do
+  labels:
+    app.kubernetes.io/name: postgres-operator
+spec:
+  group: acid.zalan.do
+  names:
+    kind: OperatorConfiguration
+    listKind: OperatorConfigurationList
+    plural: operatorconfigurations
+    singular: operatorconfiguration
+    shortNames:
+    - opconfig
+    categories:
+    - all
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Image
+      type: string
+      description: Spilo image to be used for Pods
+      jsonPath: .configuration.docker_image
+    - name: Cluster-Label
+      type: string
+      description: Label for K8s resources created by operator
+      jsonPath: .configuration.kubernetes.cluster_name_label
+    - name: Service-Account
+      type: string
+      description: Name of service account to be used
+      jsonPath: .configuration.kubernetes.pod_service_account_name
+    - name: Min-Instances
+      type: integer
+      description: Minimum number of instances per Postgres cluster
+      jsonPath: .configuration.min_instances
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+          - kind
+          - apiVersion
+          - configuration
+        properties:
+          kind:
+            type: string
+            enum:
+            - OperatorConfiguration
+          apiVersion:
+            type: string
+            enum:
+            - acid.zalan.do/v1
+          configuration:
+            type: object
+            properties:
+              crd_categories:
+                type: array
+                nullable: true
+                items:
+                  type: string
+              docker_image:
+                type: string
+                default: "ghcr.io/zalando/spilo-15:3.0-p1"
+              enable_crd_registration:
+                type: boolean
+                default: true
+              enable_crd_validation:
+                type: boolean
+                description: deprecated
+                default: true
+              enable_lazy_spilo_upgrade:
+                type: boolean
+                default: false
+              enable_pgversion_env_var:
+                type: boolean
+                default: true
+              enable_shm_volume:
+                type: boolean
+                default: true
+              enable_spilo_wal_path_compat:
+                type: boolean
+                default: false
+              enable_team_id_clustername_prefix:
+                type: boolean
+                default: false
+              etcd_host:
+                type: string
+                default: ""
+              ignore_instance_limits_annotation_key:
+                type: string
+              kubernetes_use_configmaps:
+                type: boolean
+                default: false
+              max_instances:
+                type: integer
+                description: "-1 = disabled"
+                minimum: -1
+                default: -1
+              min_instances:
+                type: integer
+                description: "-1 = disabled"
+                minimum: -1
+                default: -1
+              resync_period:
+                type: string
+                default: "30m"
+              repair_period:
+                type: string
+                default: "5m"
+              set_memory_request_to_limit:
+                type: boolean
+                default: false
+              sidecar_docker_images:
+                type: object
+                additionalProperties:
+                  type: string
+              sidecars:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              workers:
+                type: integer
+                minimum: 1
+                default: 8
+              users:
+                type: object
+                properties:
+                  additional_owner_roles:
+                    type: array
+                    nullable: true
+                    items:
+                      type: string
+                  enable_password_rotation:
+                    type: boolean
+                    default: false
+                  password_rotation_interval:
+                    type: integer
+                    default: 90
+                  password_rotation_user_retention:
+                    type: integer
+                    default: 180
+                  replication_username:
+                     type: string
+                     default: standby
+                  super_username:
+                     type: string
+                     default: postgres
+              major_version_upgrade:
+                type: object
+                properties:
+                  major_version_upgrade_mode:
+                    type: string
+                    default: "off"
+                  major_version_upgrade_team_allow_list:
+                    type: array
+                    items:
+                      type: string
+                  minimal_major_version:
+                    type: string
+                    default: "11"
+                  target_major_version:
+                    type: string
+                    default: "15"
+              kubernetes:
+                type: object
+                properties:
+                  additional_pod_capabilities:
+                    type: array
+                    items:
+                      type: string
+                  cluster_domain:
+                    type: string
+                    default: "cluster.local"
+                  cluster_labels:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    default:
+                      application: spilo
+                  cluster_name_label:
+                    type: string
+                    default: "cluster-name"
+                  custom_pod_annotations:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  delete_annotation_date_key:
+                    type: string
+                  delete_annotation_name_key:
+                    type: string
+                  downscaler_annotations:
+                    type: array
+                    items:
+                      type: string
+                  enable_cross_namespace_secret:
+                    type: boolean
+                    default: false
+                  enable_init_containers:
+                    type: boolean
+                    default: true
+                  enable_pod_antiaffinity:
+                    type: boolean
+                    default: false
+                  enable_pod_disruption_budget:
+                    type: boolean
+                    default: true
+                  enable_readiness_probe:
+                    type: boolean
+                    default: false
+                  enable_sidecars:
+                    type: boolean
+                    default: true
+                  ignored_annotations:
+                    type: array
+                    items:
+                      type: string
+                  infrastructure_roles_secret_name:
+                    type: string
+                  infrastructure_roles_secrets:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      required:
+                        - secretname
+                        - userkey
+                        - passwordkey
+                      properties:
+                        secretname:
+                          type: string
+                        userkey:
+                          type: string
+                        passwordkey:
+                          type: string
+                        rolekey:
+                          type: string
+                        defaultuservalue:
+                          type: string
+                        defaultrolevalue:
+                          type: string
+                        details:
+                          type: string
+                        template:
+                          type: boolean
+                  inherited_annotations:
+                    type: array
+                    items:
+                      type: string
+                  inherited_labels:
+                    type: array
+                    items:
+                      type: string
+                  master_pod_move_timeout:
+                    type: string
+                    default: "20m"
+                  node_readiness_label:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  node_readiness_label_merge:
+                    type: string
+                    enum:
+                      - "AND"
+                      - "OR"
+                  oauth_token_secret_name:
+                    type: string
+                    default: "postgresql-operator"
+                  pdb_name_format:
+                    type: string
+                    default: "postgres-{cluster}-pdb"
+                  pod_antiaffinity_preferred_during_scheduling:
+                    type: boolean
+                    default: false
+                  pod_antiaffinity_topology_key:
+                    type: string
+                    default: "kubernetes.io/hostname"
+                  pod_environment_configmap:
+                    type: string
+                  pod_environment_secret:
+                    type: string
+                  pod_management_policy:
+                    type: string
+                    enum:
+                      - "ordered_ready"
+                      - "parallel"
+                    default: "ordered_ready"
+                  pod_priority_class_name:
+                    type: string
+                  pod_role_label:
+                    type: string
+                    default: "spilo-role"
+                  pod_service_account_definition:
+                    type: string
+                    default: ""
+                  pod_service_account_name:
+                    type: string
+                    default: "postgres-pod"
+                  pod_service_account_role_binding_definition:
+                    type: string
+                    default: ""
+                  pod_terminate_grace_period:
+                    type: string
+                    default: "5m"
+                  secret_name_template:
+                    type: string
+                    default: "{username}.{cluster}.credentials.{tprkind}.{tprgroup}"
+                  share_pgsocket_with_sidecars:
+                    type: boolean
+                    default: false
+                  spilo_allow_privilege_escalation:
+                    type: boolean
+                    default: true
+                  spilo_runasuser:
+                    type: integer
+                  spilo_runasgroup:
+                    type: integer
+                  spilo_fsgroup:
+                    type: integer
+                  spilo_privileged:
+                    type: boolean
+                    default: false
+                  storage_resize_mode:
+                    type: string
+                    enum:
+                      - "ebs"
+                      - "mixed"
+                      - "pvc"
+                      - "off"
+                    default: "pvc"
+                  toleration:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  watched_namespace:
+                    type: string
+              postgres_pod_resources:
+                type: object
+                properties:
+                  default_cpu_limit:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "1"
+                  default_cpu_request:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "100m"
+                  default_memory_limit:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "500Mi"
+                  default_memory_request:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "100Mi"
+                  max_cpu_request:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                  max_memory_request:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                  min_cpu_limit:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "250m"
+                  min_memory_limit:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "250Mi"
+              timeouts:
+                type: object
+                properties:
+                  patroni_api_check_interval:
+                    type: string
+                    default: "1s"
+                  patroni_api_check_timeout:
+                    type: string
+                    default: "5s"
+                  pod_label_wait_timeout:
+                    type: string
+                    default: "10m"
+                  pod_deletion_wait_timeout:
+                    type: string
+                    default: "10m"
+                  ready_wait_interval:
+                    type: string
+                    default: "4s"
+                  ready_wait_timeout:
+                    type: string
+                    default: "30s"
+                  resource_check_interval:
+                    type: string
+                    default: "3s"
+                  resource_check_timeout:
+                    type: string
+                    default: "10m"
+              load_balancer:
+                type: object
+                properties:
+                  custom_service_annotations:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  db_hosted_zone:
+                    type: string
+                    default: "db.example.com"
+                  enable_master_load_balancer:
+                    type: boolean
+                    default: true
+                  enable_master_pooler_load_balancer:
+                    type: boolean
+                    default: false
+                  enable_replica_load_balancer:
+                    type: boolean
+                    default: false
+                  enable_replica_pooler_load_balancer:
+                    type: boolean
+                    default: false
+                  external_traffic_policy:
+                    type: string
+                    enum:
+                      - "Cluster"
+                      - "Local"
+                    default: "Cluster"
+                  master_dns_name_format:
+                    type: string
+                    default: "{cluster}.{namespace}.{hostedzone}"
+                  master_legacy_dns_name_format:
+                    type: string
+                    default: "{cluster}.{team}.{hostedzone}"
+                  replica_dns_name_format:
+                    type: string
+                    default: "{cluster}-repl.{namespace}.{hostedzone}"
+                  replica_legacy_dns_name_format:
+                    type: string
+                    default: "{cluster}-repl.{team}.{hostedzone}"
+              aws_or_gcp:
+                type: object
+                properties:
+                  additional_secret_mount:
+                    type: string
+                  additional_secret_mount_path:
+                    type: string
+                    default: "/meta/credentials"
+                  aws_region:
+                    type: string
+                    default: "eu-central-1"
+                  enable_ebs_gp3_migration:
+                    type: boolean
+                    default: false
+                  enable_ebs_gp3_migration_max_size:
+                    type: integer
+                    default: 1000
+                  gcp_credentials:
+                    type: string
+                  kube_iam_role:
+                    type: string
+                  log_s3_bucket:
+                    type: string
+                  wal_az_storage_account:
+                    type: string
+                  wal_gs_bucket:
+                    type: string
+                  wal_s3_bucket:
+                    type: string
+              logical_backup:
+                type: object
+                properties:
+                  logical_backup_azure_storage_account_name:
+                    type: string
+                  logical_backup_azure_storage_container:
+                    type: string
+                  logical_backup_azure_storage_account_key:
+                    type: string
+                  logical_backup_cpu_limit:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                  logical_backup_cpu_request:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                  logical_backup_docker_image:
+                    type: string
+                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
+                  logical_backup_google_application_credentials:
+                    type: string
+                  logical_backup_job_prefix:
+                    type: string
+                    default: "logical-backup-"
+                  logical_backup_memory_limit:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                  logical_backup_memory_request:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                  logical_backup_provider:
+                    type: string
+                    enum:
+                      - "az"
+                      - "gcs"
+                      - "s3"
+                    default: "s3"
+                  logical_backup_s3_access_key_id:
+                    type: string
+                  logical_backup_s3_bucket:
+                    type: string
+                  logical_backup_s3_endpoint:
+                    type: string
+                  logical_backup_s3_region:
+                    type: string
+                  logical_backup_s3_secret_access_key:
+                    type: string
+                  logical_backup_s3_sse:
+                    type: string
+                  logical_backup_s3_retention_time:
+                    type: string
+                  logical_backup_schedule:
+                    type: string
+                    pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+                    default: "30 00 * * *"
+              debug:
+                type: object
+                properties:
+                  debug_logging:
+                    type: boolean
+                    default: true
+                  enable_database_access:
+                    type: boolean
+                    default: true
+              teams_api:
+                type: object
+                properties:
+                  enable_admin_role_for_users:
+                    type: boolean
+                    default: true
+                  enable_postgres_team_crd:
+                    type: boolean
+                    default: true
+                  enable_postgres_team_crd_superusers:
+                    type: boolean
+                    default: false
+                  enable_team_member_deprecation:
+                    type: boolean
+                    default: false
+                  enable_team_superuser:
+                    type: boolean
+                    default: false
+                  enable_teams_api:
+                    type: boolean
+                    default: true
+                  pam_configuration:
+                    type: string
+                    default: "https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees"
+                  pam_role_name:
+                    type: string
+                    default: "zalandos"
+                  postgres_superuser_teams:
+                    type: array
+                    items:
+                      type: string
+                  protected_role_names:
+                    type: array
+                    items:
+                      type: string
+                    default:
+                    - admin
+                    - cron_admin
+                  role_deletion_suffix:
+                    type: string
+                    default: "_deleted"
+                  team_admin_role:
+                    type: string
+                    default: "admin"
+                  team_api_role_configuration:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    default:
+                      log_statement: all
+                  teams_api_url:
+                    type: string
+                    default: "https://teams.example.com/api/"
+              logging_rest_api:
+                type: object
+                properties:
+                  api_port:
+                    type: integer
+                    default: 8080
+                  cluster_history_entries:
+                    type: integer
+                    default: 1000
+                  ring_log_lines:
+                    type: integer
+                    default: 100
+              scalyr:  # deprecated
+                type: object
+                properties:
+                  scalyr_api_key:
+                    type: string
+                  scalyr_cpu_limit:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "1"
+                  scalyr_cpu_request:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "100m"
+                  scalyr_image:
+                    type: string
+                  scalyr_memory_limit:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "500Mi"
+                  scalyr_memory_request:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "50Mi"
+                  scalyr_server_url:
+                    type: string
+                    default: "https://upload.eu.scalyr.com"
+              connection_pooler:
+                type: object
+                properties:
+                  connection_pooler_schema:
+                    type: string
+                    default: "pooler"
+                  connection_pooler_user:
+                    type: string
+                    default: "pooler"
+                  connection_pooler_image:
+                    type: string
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+                  connection_pooler_max_db_connections:
+                    type: integer
+                    default: 60
+                  connection_pooler_mode:
+                    type: string
+                    enum:
+                      - "session"
+                      - "transaction"
+                    default: "transaction"
+                  connection_pooler_number_of_instances:
+                    type: integer
+                    minimum: 1
+                    default: 2
+                  connection_pooler_default_cpu_limit:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "1"
+                  connection_pooler_default_cpu_request:
+                    type: string
+                    pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                    default: "500m"
+                  connection_pooler_default_memory_limit:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "100Mi"
+                  connection_pooler_default_memory_request:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    default: "100Mi"
+              patroni:
+                type: object
+                properties:
+                  enable_patroni_failsafe_mode:
+                    type: boolean
+                    default: false
+          status:
+            type: object
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresqls.acid.zalan.do
+  labels:
+    app.kubernetes.io/name: postgres-operator
+spec:
+  group: acid.zalan.do
+  names:
+    kind: postgresql
+    listKind: postgresqlList
+    plural: postgresqls
+    singular: postgresql
+    shortNames:
+    - pg
+    categories:
+    - all
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Team
+      type: string
+      description: Team responsible for Postgres cluster
+      jsonPath: .spec.teamId
+    - name: Version
+      type: string
+      description: PostgreSQL version
+      jsonPath: .spec.postgresql.version
+    - name: Pods
+      type: integer
+      description: Number of Pods per Postgres cluster
+      jsonPath: .spec.numberOfInstances
+    - name: Volume
+      type: string
+      description: Size of the bound volume
+      jsonPath: .spec.volume.size
+    - name: CPU-Request
+      type: string
+      description: Requested CPU for Postgres containers
+      jsonPath: .spec.resources.requests.cpu
+    - name: Memory-Request
+      type: string
+      description: Requested memory for Postgres containers
+      jsonPath: .spec.resources.requests.memory
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Status
+      type: string
+      description: Current sync status of postgresql resource
+      jsonPath: .status.PostgresClusterStatus
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+          - kind
+          - apiVersion
+          - spec
+        properties:
+          kind:
+            type: string
+            enum:
+              - postgresql
+          apiVersion:
+            type: string
+            enum:
+              - acid.zalan.do/v1
+          spec:
+            type: object
+            required:
+              - numberOfInstances
+              - teamId
+              - postgresql
+              - volume
+            properties:
+              additionalVolumes:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - mountPath
+                    - volumeSource
+                  properties:
+                    name:
+                      type: string
+                    mountPath:
+                      type: string
+                    targetContainers:
+                      type: array
+                      nullable: true
+                      items:
+                        type: string
+                    volumeSource:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    subPath:
+                      type: string
+              allowedSourceRanges:
+                type: array
+                nullable: true
+                items:
+                  type: string
+                  pattern: '^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\/(\d|[1-2]\d|3[0-2])$'
+              clone:
+                type: object
+                required:
+                  - cluster
+                properties:
+                  cluster:
+                    type: string
+                  s3_endpoint:
+                    type: string
+                  s3_access_key_id:
+                    type: string
+                  s3_secret_access_key:
+                    type: string
+                  s3_force_path_style:
+                    type: boolean
+                  s3_wal_path:
+                    type: string
+                  timestamp:
+                    type: string
+                    pattern: '^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$'
+                    # The regexp matches the date-time format (RFC 3339 Section 5.6) that specifies a timezone as an offset relative to UTC
+                    # Example: 1996-12-19T16:39:57-08:00
+                    # Note: this field requires a timezone
+                  uid:
+                    format: uuid
+                    type: string
+              connectionPooler:
+                type: object
+                properties:
+                  dockerImage:
+                    type: string
+                  maxDBConnections:
+                    type: integer
+                  mode:
+                    type: string
+                    enum:
+                      - "session"
+                      - "transaction"
+                  numberOfInstances:
+                    type: integer
+                    minimum: 1
+                  resources:
+                    type: object
+                    properties:
+                      limits:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                          memory:
+                            type: string
+                            pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                      requests:
+                        type: object
+                        properties:
+                          cpu:
+                            type: string
+                            pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                          memory:
+                            type: string
+                            pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                  schema:
+                    type: string
+                  user:
+                    type: string
+              databases:
+                type: object
+                additionalProperties:
+                  type: string
+                # Note: usernames specified here as database owners must be declared in the users key of the spec key.
+              dockerImage:
+                type: string
+              enableConnectionPooler:
+                type: boolean
+              enableReplicaConnectionPooler:
+                type: boolean
+              enableLogicalBackup:
+                type: boolean
+              enableMasterLoadBalancer:
+                type: boolean
+              enableMasterPoolerLoadBalancer:
+                type: boolean
+              enableReplicaLoadBalancer:
+                type: boolean
+              enableReplicaPoolerLoadBalancer:
+                type: boolean
+              enableShmVolume:
+                type: boolean
+              env:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              init_containers:
+                type: array
+                description: deprecated
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              initContainers:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              logicalBackupSchedule:
+                type: string
+                pattern: '^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$'
+              maintenanceWindows:
+                type: array
+                items:
+                  type: string
+                  pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
+              masterServiceAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              nodeAffinity:
+                type: object
+                properties:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - preference
+                      - weight
+                      properties:
+                        preference:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                        weight:
+                          format: int32
+                          type: integer
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    type: object
+                    required:
+                    - nodeSelectorTerms
+                    properties:
+                      nodeSelectorTerms:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            matchExpressions:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+                            matchFields:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - key
+                                - operator
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    type: array
+                                    items:
+                                      type: string
+              numberOfInstances:
+                type: integer
+                minimum: 0
+              patroni:
+                type: object
+                properties:
+                  failsafe_mode:
+                    type: boolean
+                  initdb:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  loop_wait:
+                    type: integer
+                  maximum_lag_on_failover:
+                    type: integer
+                  pg_hba:
+                    type: array
+                    items:
+                      type: string
+                  retry_timeout:
+                    type: integer
+                  slots:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      additionalProperties:
+                        type: string
+                  synchronous_mode:
+                    type: boolean
+                  synchronous_mode_strict:
+                    type: boolean
+                  synchronous_node_count:
+                    type: integer
+                  ttl:
+                    type: integer
+              podAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              pod_priority_class_name:
+                type: string
+                description: deprecated
+              podPriorityClassName:
+                type: string
+              postgresql:
+                type: object
+                required:
+                  - version
+                properties:
+                  version:
+                    type: string
+                    enum:
+                      - "10"
+                      - "11"
+                      - "12"
+                      - "13"
+                      - "14"
+                      - "15"
+                  parameters:
+                    type: object
+                    additionalProperties:
+                      type: string
+              preparedDatabases:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    defaultUsers:
+                      type: boolean
+                    extensions:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    schemas:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          defaultUsers:
+                            type: boolean
+                          defaultRoles:
+                            type: boolean
+                    secretNamespace:
+                      type: string
+              replicaLoadBalancer:
+                type: boolean
+                description: deprecated
+              replicaServiceAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              resources:
+                type: object
+                properties:
+                  limits:
+                    type: object
+                    properties:
+                      cpu:
+                        type: string
+                        # Decimal natural followed by m, or decimal natural followed by
+                        # dot followed by up to three decimal digits.
+                        #
+                        # This is because the Kubernetes CPU resource has millis as the
+                        # maximum precision.  The actual values are checked in code
+                        # because the regular expression would be huge and horrible and
+                        # not very helpful in validation error messages; this one checks
+                        # only the format of the given number.
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                        # Note: the value specified here must not be zero or be lower
+                        # than the corresponding request.
+                      memory:
+                        type: string
+                        # You can express memory as a plain integer or as a fixed-point
+                        # integer using one of these suffixes: E, P, T, G, M, k. You can
+                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                        # Note: the value specified here must not be zero or be higher
+                        # than the corresponding limit.
+                  requests:
+                    type: object
+                    properties:
+                      cpu:
+                        type: string
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                      memory:
+                        type: string
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+              schedulerName:
+                type: string
+              serviceAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              sidecars:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              spiloRunAsUser:
+                type: integer
+              spiloRunAsGroup:
+                type: integer
+              spiloFSGroup:
+                type: integer
+              standby:
+                type: object
+                properties:
+                  s3_wal_path:
+                    type: string
+                  gs_wal_path:
+                    type: string
+                  standby_host:
+                    type: string
+                  standby_port:
+                    type: string
+                oneOf:
+                - required:
+                  - s3_wal_path
+                - required:
+                  - gs_wal_path
+                - required:
+                  - standby_host
+              streams:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - applicationId
+                    - database
+                    - tables
+                  properties:
+                    applicationId:
+                      type: string
+                    batchSize:
+                      type: integer
+                    database:
+                      type: string
+                    filter:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tables:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        required:
+                          - eventType
+                        properties:
+                          eventType:
+                            type: string
+                          idColumn:
+                            type: string
+                          payloadColumn:
+                            type: string
+              teamId:
+                type: string
+              tls:
+                type: object
+                required:
+                  - secretName
+                properties:
+                  secretName:
+                    type: string
+                  certificateFile:
+                    type: string
+                  privateKeyFile:
+                    type: string
+                  caFile:
+                    type: string
+                  caSecretName:
+                    type: string
+              tolerations:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    operator:
+                      type: string
+                      enum:
+                        - Equal
+                        - Exists
+                    value:
+                      type: string
+                    effect:
+                      type: string
+                      enum:
+                        - NoExecute
+                        - NoSchedule
+                        - PreferNoSchedule
+                    tolerationSeconds:
+                      type: integer
+              useLoadBalancer:
+                type: boolean
+                description: deprecated
+              users:
+                type: object
+                additionalProperties:
+                  type: array
+                  nullable: true
+                  items:
+                    type: string
+                    enum:
+                    - bypassrls
+                    - BYPASSRLS
+                    - nobypassrls
+                    - NOBYPASSRLS
+                    - createdb
+                    - CREATEDB
+                    - nocreatedb
+                    - NOCREATEDB
+                    - createrole
+                    - CREATEROLE
+                    - nocreaterole
+                    - NOCREATEROLE
+                    - inherit
+                    - INHERIT
+                    - noinherit
+                    - NOINHERIT
+                    - login
+                    - LOGIN
+                    - nologin
+                    - NOLOGIN
+                    - replication
+                    - REPLICATION
+                    - noreplication
+                    - NOREPLICATION
+                    - superuser
+                    - SUPERUSER
+                    - nosuperuser
+                    - NOSUPERUSER
+              usersWithInPlaceSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
+              usersWithSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
+              volume:
+                type: object
+                required:
+                  - size
+                properties:
+                  iops:
+                    type: integer
+                  selector:
+                    type: object
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - key
+                            - operator
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                              enum:
+                                - DoesNotExist
+                                - Exists
+                                - In
+                                - NotIn
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                  size:
+                    type: string
+                    pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                    # Note: the value specified here must not be zero.
+                  storageClass:
+                    type: string
+                  subPath:
+                    type: string
+                  throughput:
+                    type: integer
+          status:
+            type: object
+            additionalProperties:
+              type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresteams.acid.zalan.do
+  labels:
+    app.kubernetes.io/name: postgres-operator
+spec:
+  group: acid.zalan.do
+  names:
+    kind: PostgresTeam
+    listKind: PostgresTeamList
+    plural: postgresteams
+    singular: postgresteam
+    shortNames:
+    - pgteam
+    categories:
+    - all
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+          - kind
+          - apiVersion
+          - spec
+        properties:
+          kind:
+            type: string
+            enum:
+              - PostgresTeam
+          apiVersion:
+            type: string
+            enum:
+              - acid.zalan.do/v1
+          spec:
+            type: object
+            properties:
+              additionalSuperuserTeams:
+                type: object
+                description: "Map for teamId and associated additional superuser teams"
+                additionalProperties:
+                  type: array
+                  nullable: true
+                  description: "List of teams to become Postgres superusers"
+                  items:
+                    type: string
+              additionalTeams:
+                type: object
+                description: "Map for teamId and associated additional teams"
+                additionalProperties:
+                  type: array
+                  nullable: true
+                  description: "List of teams whose members will also be added to the Postgres cluster"
+                  items:
+                    type: string
+              additionalMembers:
+                type: object
+                description: "Map for teamId and associated additional users"
+                additionalProperties:
+                  type: array
+                  nullable: true
+                  description: "List of users who will also be added to the Postgres cluster"
+                  items:
+                    type: string

--- a/kubernetes/cray-postgres-operator/templates/configmaps.yaml
+++ b/kubernetes/cray-postgres-operator/templates/configmaps.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -29,3 +29,4 @@ metadata:
 data:
   DEVELOP: "1"
   SPILO_PROVIDER: "local"
+  PATRONI_KUBERNETES_BYPASS_API_SERVICE: "true"

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -62,3 +62,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "cray-postgres-operator.fullname" . }}-jobs-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postgres-pod
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: postgres-pod
+subjects:
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: services
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: spire
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: argo
+- kind: ServiceAccount
+  name: postgres-pod
+  namespace: sma

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -26,13 +26,13 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
 
 postgres-operator:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator
-    tag: v1.8.2
+    tag: v1.10.1
     pullPolicy: "IfNotPresent"
 
   podAnnotations:
@@ -42,7 +42,7 @@ postgres-operator:
 
   # general configuration parameters
   configGeneral:
-    docker_image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/spilo-14:2.1-p7
+    docker_image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     resync_period: 5m
     enable_pgversion_env_var: false  # needed for rollback to succeed
 
@@ -112,7 +112,7 @@ postgres-operator:
   nodeSelector: {}
 
   configLogicalBackup:
-    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.8.2"
+    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
     logical_backup_job_prefix: logical-backup-
     logical_backup_provider: s3
     logical_backup_s3_bucket: postgres-backup
@@ -124,4 +124,4 @@ postgres-operator:
     logical_backup_s3_sse: ""
     logical_backup_schedule: "0 12 * * *"  # everyday at noon
   configConnectionPooler:
-    connection_pooler_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-22"
+    connection_pooler_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-27"


### PR DESCRIPTION
## Summary and Scope

Upgrade cray-postgres-operator to use cray-postgres version 1.10.1 for CSM 1.7.

The following changes were made:
- Using postgres-operator chart 1.10.1
- Added postgres-pod roleBinding to the default namespace to allow Patroni to access the Kubernetes API.
- Setting the PATRONI_KUBERNETES_BYPASS_API_SERVICE variable in the postgres-pod-env
- Add CRDs for 1.10.1. These will be applied in prerequisites.sh by using the following command

```text
ncn-m001:~/leliasen # tar --extract --file=cray-postgres-operator-1.10.0-20250123172945+a2f1fd4.tgz --to-stdout cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml | kubectl apply -f -
Warning: resource customresourcedefinitions/operatorconfigurations.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/operatorconfigurations.acid.zalan.do configured
Warning: resource customresourcedefinitions/postgresqls.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/postgresqls.acid.zalan.do configured
Warning: resource customresourcedefinitions/postgresteams.acid.zalan.do is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/postgresteams.acid.zalan.do configured
```

I attempted to install these CRDs in a pre-upgrade helm hook however helm still prevented the upgrade. Since this upgrade is necessary in `prerequisites.sh`, I will apply the CRDs in `prerequisites.sh` as well.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7335](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7335)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau

### Test description:

I upgraded the cray-postgres-operator chart. I saw that all postgres pods were using the new container images and were working properly. I also tested a helm rollback which ran successfully. 

I ran `/opt/cray/platform-utils/ncnPostgresHealthChecks.sh` and all check passed successfully.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

