### PR TITLE
CASMPET-7347: enable patroni failsafe mode

### DIFF
--- a/kubernetes/cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml
+++ b/kubernetes/cray-postgres-operator/files/postgres-operator-crds-1.10.1.yaml
@@ -698,7 +698,7 @@ spec:
                 properties:
                   enable_patroni_failsafe_mode:
                     type: boolean
-                    default: false
+                    default: true
           status:
             type: object
             additionalProperties:


### PR DESCRIPTION
## Summary and Scope

This PR turns on Patroni failsafe mode to prevent leader demotion issue when k8s api server is temporarily down. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7347](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7347)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `taryon`
  * Local development environment
  * Virtual Shasta

### Test description:

After upgrading crd and the cray-postgres-operator chart, k8s api server is restarted and verified that postgres service charts are still up and running.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

