### PR TITLE
CASMTRIAGE-8382 - Patroni DCS failsafe mode is still disabled when it should be enabled

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.10.2
+version: 1.10.3
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -128,4 +128,4 @@ postgres-operator:
 
   # enable Patroni DCS failsafe_mode feature
   configPatroni:
-    enable_patroni_failsafe_mode: false
+    enable_patroni_failsafe_mode: true

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -125,3 +125,7 @@ postgres-operator:
     logical_backup_schedule: "0 12 * * *"  # everyday at noon
   configConnectionPooler:
     connection_pooler_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-27"
+
+  # enable Patroni DCS failsafe_mode feature
+  configPatroni:
+    enable_patroni_failsafe_mode: false


### PR DESCRIPTION
## Summary and Scope

Follow on from [CASMPET-7347](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7347)/https://github.com/Cray-HPE/cray-postgres-operator/pull/23 which enabled the patroni DCS failsafe mode in the CRDs.

This change did not have the desired impact because the `postgres-operator` sub-chart has this feature disabled in the `OperatorConfiguration` resource it creates.

This PR enables the feature so it is applied to the `OperatorConfiguration` and database clusters.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8382](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8382)

## Testing

### Tested on:

  * `wasp`

### Test description:

Verified state of system, patroni failsafe mode is disabled.
```
ncn-m001:~ # kubectl -n services get operatorconfigurations.acid.zalan.do cray-postgres-operator -o yaml | grep failsafe
    enable_patroni_failsafe_mode: false

ncn-m001:~ # kubectl -n services exec -it cray-dns-powerdns-postgres-0 -c postgres -- patronictl show-config | grep failsafe
failsafe_mode: false
```
Installed new Helm chart.

Patroni failsafe mode is now enabled and has been applied to the database clusters.

```
ncn-m001:~ # kubectl -n services get operatorconfigurations.acid.zalan.do cray-postgres-operator -o yaml | grep failsafe
    enable_patroni_failsafe_mode: true

ncn-m001:~ # kubectl -n services exec -it cray-dns-powerdns-postgres-0 -c postgres -- patronictl show-config | grep failsafe
failsafe_mode: true
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

