### PR TITLE
CASMPET-7478: Upgrade spilo-15 image to spilo-15:3.2-p1

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.10.3
+version: 1.10.4
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -44,8 +44,8 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1
     - name: postgres-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
-    - name: spilo-14
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
+    - name: spilo-15
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
     - name: logical-backup
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1
     - name: pgbouncer

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -22,6 +22,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 # RoleBinding for PSP with cray-postgres-operator ServiceAccount in services namespace
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -35,6 +36,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "cray-postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020, 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2021-2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.24.17
+    tag: 1.32.2
 
 postgres-operator:
   image:
@@ -42,7 +42,7 @@ postgres-operator:
 
   # general configuration parameters
   configGeneral:
-    docker_image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
+    docker_image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
     resync_period: 5m
     enable_pgversion_env_var: false  # needed for rollback to succeed
 


### PR DESCRIPTION
## Summary and Scope

* CASMPET-7478: Upgrade spilo-15 image to spilo-15:3.2-p1
* CASMPET-7669: Wrap rbac psp rolebinding in conditional so only created if PodSecurityPolicy capability exists

## Issues and Related PRs
* Resolves [CASMPET-7478](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7478)
* Resolves [CASMPET-7669](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7669)

## Testing
Tested on vShasta system `beau`.

Ran `remove_psp.sh` script to clean up left over PSP rolebindings before upgrading to `cray-postgres-operator` 1.10.4-20250910151804+8b00e0a chart.
```
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "argo-psp" deleted
rolebinding.rbac.authorization.k8s.io "cert-manager-psp" deleted
rolebinding.rbac.authorization.k8s.io "istio-system-psp" deleted
rolebinding.rbac.authorization.k8s.io "loftsman-psp" deleted
rolebinding.rbac.authorization.k8s.io "operators-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-console-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-node-discovery" deleted
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "services-default-psp" deleted
rolebinding.rbac.authorization.k8s.io "sonar-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-provisioner-psp" deleted
rolebinding.rbac.authorization.k8s.io "spire-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "vault-psp" deleted
```
After script is executed, the `cray-postgres-operator-psp` rolebinding no longer exists.
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
PSP_ONLY_SA=

delete_sa(): NOP
pit:~/studenym #
```

Successfully upgraded helm chart.
```
pit:~/studenym/cray-postgres-operator # helm history -n services cray-postgres-operator
REVISION	UPDATED                 	STATUS    	CHART                        	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:18 2025	superseded	cray-postgres-operator-1.10.3	1.10.1     	Install complete
2       	Tue Sep  9 18:55:38 2025	superseded	cray-postgres-operator-1.10.4	1.10.1     	Upgrade complete
3       	Tue Sep  9 19:19:40 2025	deployed  	cray-postgres-operator-1.10.3	1.10.1     	Rollback to 1
pit:~/studenym/cray-postgres-operator # helm upgrade -n services cray-postgres-operator cray-postgres-operator-1.10.4-20250910151804+8b00e0a.tgz
Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Wed Sep 10 16:10:25 2025
NAMESPACE: services
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
pit:~/studenym/cray-postgres-operator # helm history -n services cray-postgres-operator
REVISION	UPDATED                 	STATUS    	CHART                                               	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:18 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Install complete
2       	Tue Sep  9 18:55:38 2025	superseded	cray-postgres-operator-1.10.4                       	1.10.1     	Upgrade complete
3       	Tue Sep  9 19:19:40 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Rollback to 1
4       	Wed Sep 10 16:10:25 2025	deployed  	cray-postgres-operator-1.10.4-20250910151804+8b00e0a	1.10.1     	Upgrade complete
pit:~/studenym/cray-postgres-operator # kubectl get pods -n services | grep postgres-operator
cray-postgres-operator-5c58df5fc-xx4qj                            2/2     Running     0             52s
cray-postgres-operator-inject-secret-95tcj                        0/1     Completed   0             54s
pit:~/studenym/cray-postgres-operator #
pit:~/studenym/cray-postgres-operator # kubectl get pods -A | grep postgres
argo              cray-nls-postgres-0                                               3/3     Running       0             81s
argo              cray-nls-postgres-1                                               3/3     Running       0             2m6s
argo              cray-nls-postgres-2                                               3/3     Running       0             106s
services          cfs-ara-postgres-0                                                3/3     Running       0             73s
services          cfs-ara-postgres-1                                                3/3     Running       0             2m10s
services          cfs-ara-postgres-2                                                3/3     Running       0             100s
services          cfs-ara-wait-for-postgres-1-gdzx6                                 0/2     Completed     0             30d
services          cray-console-data-postgres-0                                      3/3     Running       0             65s
services          cray-console-data-postgres-1                                      3/3     Running       0             2m7s
services          cray-console-data-postgres-2                                      3/3     Running       0             97s
services          cray-console-data-wait-for-postgres-1-xq5gd                       0/2     Completed     0             30d
services          cray-dhcp-kea-postgres-0                                          3/3     Running       0             66s
services          cray-dhcp-kea-postgres-1                                          3/3     Running       0             2m6s
services          cray-dhcp-kea-postgres-2                                          3/3     Running       0             101s
services          cray-dns-powerdns-postgres-0                                      3/3     Running       0             76s
services          cray-dns-powerdns-postgres-1                                      3/3     Running       0             2m6s
services          cray-dns-powerdns-postgres-2                                      3/3     Running       0             105s
services          cray-dns-powerdns-wait-for-postgres-1-xvhtr                       0/3     Completed     0             30d
services          cray-postgres-operator-5c58df5fc-xx4qj                            2/2     Running       0             2m55s
services          cray-postgres-operator-inject-secret-95tcj                        0/1     Completed     0             2m57s
services          cray-sls-postgres-0                                               3/3     Running       0             66s
services          cray-sls-postgres-1                                               3/3     Running       0             2m7s
services          cray-sls-postgres-2                                               3/3     Running       0             100s
services          cray-sls-wait-for-postgres-1-5gsx7                                0/3     Completed     0             30d
services          cray-smd-postgres-0                                               3/3     Running       0             73s
services          cray-smd-postgres-1                                               3/3     Running       0             2m6s
services          cray-smd-postgres-2                                               3/3     Running       0             100s
services          cray-smd-wait-for-postgres-1-2xpt4                                0/3     Completed     0             30d
services          gitea-vcs-postgres-0                                              3/3     Running       0             75s
services          gitea-vcs-postgres-1                                              3/3     Running       0             2m10s
services          gitea-vcs-postgres-2                                              3/3     Running       0             99s
services          gitea-vcs-wait-for-postgres-1-lj59l                               0/2     Completed     0             30d
services          keycloak-postgres-0                                               3/3     Terminating   0             20h
services          keycloak-postgres-1                                               3/3     Running       0             56s
services          keycloak-postgres-2                                               3/3     Running       0             28s
services          keycloak-wait-for-postgres-1-lxltf                                0/2     Completed     0             30d
spire             cray-spire-postgres-0                                             3/3     Terminating   0             20h
spire             cray-spire-postgres-1                                             3/3     Running       0             42s
spire             cray-spire-postgres-2                                             3/3     Running       0             19s
spire             cray-spire-postgres-pooler-8585bdf864-4wxl7                       2/2     Running       0             30d
spire             cray-spire-postgres-pooler-8585bdf864-nsbhj                       2/2     Running       0             30d
spire             cray-spire-postgres-pooler-8585bdf864-s2j49                       2/2     Running       0             30d
pit:~/studenym/cray-postgres-operator #
```

`cray-postgres-operator-psp` rolebinding was not created when the new chart was deployed.
```
pit:~/studenym/cray-postgres-operator # kubectl get pods -n services | grep postgres-operator
cray-postgres-operator-5c58df5fc-xx4qj                            2/2     Running     0             3m1s
cray-postgres-operator-inject-secret-95tcj                        0/1     Completed   0             3m3s
pit:~/studenym/cray-postgres-operator # cd ..
pit:~/studenym # vi remove_psp.sh
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
PSP_ONLY_SA=

delete_sa(): NOP
pit:~/studenym #
```

`postgres` clusters upgraded successfully
```
pit:~/studenym # kubectl get postgresql -A
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            15        3      2Gi                                     30d   Running
services    cfs-ara-postgres             cfs-ara             15        3      50Gi     100m          100Mi            30d   Running
services    cray-console-data-postgres   cray-console-data   15        3      2Gi      100m          256Mi            30d   Running
services    cray-dhcp-kea-postgres       cray-dhcp-kea       15        3      10Gi     500m          1Gi              30d   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   15        3      10Gi     100m          100Mi            30d   Running
services    cray-sls-postgres            cray-sls            15        3      1Gi      100m          128Mi            30d   Running
services    cray-smd-postgres            cray-smd            15        3      100Gi    100m          100Mi            30d   Running
services    gitea-vcs-postgres           gitea-vcs           15        3      50Gi     100m          256Mi            30d   Running
services    keycloak-postgres            keycloak            15        3      10Gi                                    30d   Running
spire       cray-spire-postgres          cray-spire          15        3      60Gi     500m          1Gi              30d   Running
pit:~/studenym # kubectl get pods -n argo
NAME                                                           READY   STATUS    RESTARTS      AGE
cray-iuf-metacontroller-helm-0                                 2/2     Running   0             30d
cray-iuf-metacontroller-helm-1                                 2/2     Running   0             30d
cray-nls-7cf458ff5c-8285k                                      2/2     Running   2 (30d ago)   30d
cray-nls-7cf458ff5c-86h9q                                      2/2     Running   2 (30d ago)   30d
cray-nls-7cf458ff5c-bkpn4                                      2/2     Running   2 (30d ago)   30d
cray-nls-argo-workflows-server-66df4b8868-54qzv                2/2     Running   4 (30d ago)   30d
cray-nls-argo-workflows-server-66df4b8868-qjkcr                2/2     Running   4 (30d ago)   30d
cray-nls-argo-workflows-workflow-controller-78d65cc7bc-bchg9   2/2     Running   4 (30d ago)   30d
cray-nls-argo-workflows-workflow-controller-78d65cc7bc-mm5nd   2/2     Running   4 (30d ago)   30d
cray-nls-postgres-0                                            3/3     Running   0             84m
cray-nls-postgres-1                                            3/3     Running   0             84m
cray-nls-postgres-2                                            3/3     Running   0             84m
pit:~/studenym # kubectl exec -it -n argo cray-nls-postgres-1 --sh
error: unknown flag: --sh
See 'kubectl exec --help' for usage.
pit:~/studenym # kubectl exec -it -n argo cray-nls-postgres-1 -- sh
$ patronictl list
+ Cluster: cray-nls-postgres (7537346219949789252) -------+----+-----------+
| Member              | Host        | Role    | State     | TL | Lag in MB |
+---------------------+-------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.32.3.73  | Replica | streaming |  4 |         0 |
| cray-nls-postgres-1 | 10.32.2.108 | Leader  | running   |  4 |           |
| cray-nls-postgres-2 | 10.32.4.140 | Replica | streaming |  4 |         0 |
+---------------------+-------------+---------+-----------+----+-----------+
$ patronictl version
patronictl version 3.2.2
$ exit
pit:~/studenym # kubectl get pods -n argo cray-nls-postgres-1 -o yaml | grep image
    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter@sha256:b1a9506fa9cfe12b9055372687b300e4095445dc6f977b3eca6f262224995f68
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imageID: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15@sha256:d37b0a92c8b2a7149e4246eee06e325fb34835575797ad036bbad40959d6ab13
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
pit:~/studenym #
```

Spot check of `cray-spire-postgres`
```
cray-spire-postgres-0                         3/3     Running     0          87m
cray-spire-postgres-1                         3/3     Running     0          87m
cray-spire-postgres-2                         3/3     Running     0          87m

pit:~/studenym # kubectl get pods -n spire cray-spire-postgres-0 -o yaml | grep image
    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter@sha256:b1a9506fa9cfe12b9055372687b300e4095445dc6f977b3eca6f262224995f68
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imageID: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15@sha256:d37b0a92c8b2a7149e4246eee06e325fb34835575797ad036bbad40959d6ab13
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
pit:~/studenym # kubectl exec -it -n spire cray-spire-postgres-0 -- sh
$ patronictl version
patronictl version 3.2.2
$ patronictl list
+ Cluster: cray-spire-postgres (7537349211322183752) -------+----+-----------+
| Member                | Host        | Role    | State     | TL | Lag in MB |
+-----------------------+-------------+---------+-----------+----+-----------+
| cray-spire-postgres-0 | 10.32.2.187 | Replica | streaming |  4 |         0 |
| cray-spire-postgres-1 | 10.32.4.213 | Leader  | running   |  4 |           |
| cray-spire-postgres-2 | 10.32.3.85  | Replica | streaming |  4 |         0 |
+-----------------------+-------------+---------+-----------+----+-----------+
$ exit
pit:~/studenym #
```

On rollback, I'd expect the `cray-postgres-operator-psp` rolebinding to be recreated; which is what happened.
```
pit:~/studenym # helm rollback -n services cray-postgres-operator 1
Rollback was a success! Happy Helming!
pit:~/studenym # helm history -n services cray-postgres-operator
REVISION	UPDATED                 	STATUS    	CHART                                               	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:18 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Install complete
2       	Tue Sep  9 18:55:38 2025	superseded	cray-postgres-operator-1.10.4                       	1.10.1     	Upgrade complete
3       	Tue Sep  9 19:19:40 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Rollback to 1
4       	Wed Sep 10 16:10:25 2025	superseded	cray-postgres-operator-1.10.4-20250910151804+8b00e0a	1.10.1     	Upgrade complete
5       	Wed Sep 10 17:49:25 2025	deployed  	cray-postgres-operator-1.10.3                       	1.10.1     	Rollback to 1
pit:~/studenym #
pit:~ # kubectl get rolebinding -n services | grep postgres
cray-postgres-operator-psp                            ClusterRole/privileged-psp                        58m
postgres-pod                                          ClusterRole/postgres-pod                          30d
pit:~ #
```
Re-running the `remove_psp.sh` script in `DRY_RUN`
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:  services/cray-postgres-operator-psp
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted (server dry run)
PSP_ONLY_SA=ServiceAccount/cray-postgres-operator/services:services

ServiceAccount/cray-postgres-operator/services:services ==> kind=ServiceAccount name=cray-postgres-operator ns=services
delete_sa(): NOP
pit:~/studenym #
```

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

