### PR TITLE
Revert "CASMPET-7478: Upgrade spilo-15 image to spilo-15:3.2-p1"

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.10.4
+version: 1.10.3
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -44,8 +44,8 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1
     - name: postgres-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
-    - name: spilo-15
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
+    - name: spilo-14
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     - name: logical-backup
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1
     - name: pgbouncer

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -22,7 +22,6 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 # RoleBinding for PSP with cray-postgres-operator ServiceAccount in services namespace
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -36,7 +35,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "cray-postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
-{{- end}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020, 2021-2022, 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020, 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.32.2
+    tag: 1.24.17
 
 postgres-operator:
   image:
@@ -42,7 +42,7 @@ postgres-operator:
 
   # general configuration parameters
   configGeneral:
-    docker_image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
+    docker_image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     resync_period: 5m
     enable_pgversion_env_var: false  # needed for rollback to succeed
 


### PR DESCRIPTION
Reverts Cray-HPE/cray-postgres-operator#26

The new `spilo-15:3.2-p1` image modifies the output of `patronictl list` such that the `Replica` nodes are in state `streaming` rather than `running` which breaks test `ncnPostgresHealthChecks.sh` in `platform-utils`.

```
ncn-m001:/opt/cray/platform-utils # ./ncnPostgresHealthChecks.sh
             +++++ NCN Postgres Health Checks +++++
=== Can Be Executed on any ncn worker or master node. ===
=== Executing on ncn-m001, Fri Sep 12 04:05:37 PM UTC 2025 ===

=== Postgresql Operator Version ===
artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1

=== List of Postgresql Clusters Using Operator ===
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            15        3      2Gi                                     21h   Running
services    cfs-ara-postgres             cfs-ara             15        3      50Gi     100m          100Mi            21h   Running
services    cray-console-data-postgres   cray-console-data   15        3      2Gi      100m          256Mi            21h   Running
services    cray-dhcp-kea-postgres       cray-dhcp-kea       15        3      10Gi     500m          1Gi              21h   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   15        3      10Gi     100m          100Mi            21h   Running
services    cray-sls-postgres            cray-sls            15        3      1Gi      100m          128Mi            21h   Running
services    cray-smd-postgres            cray-smd            15        3      100Gi    100m          100Mi            21h   Running
services    gitea-vcs-postgres           gitea-vcs           15        3      50Gi     100m          256Mi            21h   Running
services    keycloak-postgres            keycloak            15        3      10Gi                                    21h   Running
spire       cray-spire-postgres          cray-spire          15        3      60Gi     500m          1Gi              21h   Running

=== Look at patronictl list info for each cluster, determine and attach to leader of each cluster ===
=== Report status of postgres pods in cluster ===
-----------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-nls-postgres cluster with leader pod: cray-nls-postgres-0 ===

--- patronictl, version , list for argo leader pod cray-nls-postgres-0 ---
+ Cluster: cray-nls-postgres (7548906233256181824) -------+----+-----------+
| Member              | Host        | Role    | State     | TL | Lag in MB |
+---------------------+-------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.32.2.251 | Leader  | running   |  1 |           |
| cray-nls-postgres-1 | 10.32.4.165 | Replica | streaming |  1 |         0 |
| cray-nls-postgres-2 | 10.32.3.174 | Replica | streaming |  1 |         0 |
+---------------------+-------------+---------+-----------+----+-----------+
--- ERROR --- state of each cray-nls-postgres member cray-nls-postgres-0 is not 'running'
NAMESPACE         NAME                                                              READY   STATUS       RESTARTS      AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo              cray-nls-postgres-0                                               3/3     Running      0             21h     10.32.2.251   ncn-w001   <none>           <none>
argo              cray-nls-postgres-1                                               3/3     Running      0             21h     10.32.4.165   ncn-w002   <none>           <none>
argo              cray-nls-postgres-2                                               3/3     Running      0             21h     10.32.3.174   ncn-w003   <none>           <none>

--- Error Logs for argo "Leader Pod" cray-nls-postgres-0 ---

--- Error Logs for argo non-leader pod cray-nls-postgres-1 ---

--- Error Logs for argo non-leader pod cray-nls-postgres-2 ---

 * The logs above show up to 50 of the most recent errors *

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
<snip>
=== kubectl get pods -A -o wide | grep "NAME\|postgres-" | grep -v "operator\|Completed\|pooler" ===

NAMESPACE         NAME                                                              READY   STATUS       RESTARTS      AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo              cray-nls-postgres-0                                               3/3     Running      0             21h     10.32.2.251   ncn-w001   <none>           <none>
argo              cray-nls-postgres-1                                               3/3     Running      0             21h     10.32.4.165   ncn-w002   <none>           <none>
argo              cray-nls-postgres-2                                               3/3     Running      0             21h     10.32.3.174   ncn-w003   <none>           <none>
services          cfs-ara-postgres-0                                                3/3     Running      0             21h     10.32.3.26    ncn-w003   <none>           <none>
services          cfs-ara-postgres-1                                                3/3     Running      0             21h     10.32.4.231   ncn-w002   <none>           <none>
services          cfs-ara-postgres-2                                                3/3     Running      0             21h     10.32.2.213   ncn-w001   <none>           <none>
services          cray-console-data-postgres-0                                      3/3     Running      0             21h     10.32.3.111   ncn-w003   <none>           <none>
services          cray-console-data-postgres-1                                      3/3     Running      0             21h     10.32.2.184   ncn-w001   <none>           <none>
services          cray-console-data-postgres-2                                      3/3     Running      0             21h     10.32.4.135   ncn-w002   <none>           <none>
services          cray-dhcp-kea-postgres-0                                          3/3     Running      0             21h     10.32.2.160   ncn-w001   <none>           <none>
services          cray-dhcp-kea-postgres-1                                          3/3     Running      0             21h     10.32.3.162   ncn-w003   <none>           <none>
services          cray-dhcp-kea-postgres-2                                          3/3     Running      0             21h     10.32.4.72    ncn-w002   <none>           <none>
services          cray-dns-powerdns-postgres-0                                      3/3     Running      0             21h     10.32.2.12    ncn-w001   <none>           <none>
services          cray-dns-powerdns-postgres-1                                      3/3     Running      0             21h     10.32.4.194   ncn-w002   <none>           <none>
services          cray-dns-powerdns-postgres-2                                      3/3     Running      0             21h     10.32.3.210   ncn-w003   <none>           <none>
services          cray-sls-postgres-0                                               3/3     Running      0             21h     10.32.2.108   ncn-w001   <none>           <none>
services          cray-sls-postgres-1                                               3/3     Running      0             21h     10.32.4.31    ncn-w002   <none>           <none>
services          cray-sls-postgres-2                                               3/3     Running      0             21h     10.32.3.149   ncn-w003   <none>           <none>
services          cray-smd-postgres-0                                               3/3     Running      0             21h     10.32.2.155   ncn-w001   <none>           <none>
services          cray-smd-postgres-1                                               3/3     Running      0             21h     10.32.4.233   ncn-w002   <none>           <none>
services          cray-smd-postgres-2                                               3/3     Running      0             21h     10.32.3.124   ncn-w003   <none>           <none>
services          gitea-vcs-postgres-0                                              3/3     Running      0             21h     10.32.4.193   ncn-w002   <none>           <none>
services          gitea-vcs-postgres-1                                              3/3     Running      0             21h     10.32.2.115   ncn-w001   <none>           <none>
services          gitea-vcs-postgres-2                                              3/3     Running      0             21h     10.32.3.107   ncn-w003   <none>           <none>
services          keycloak-postgres-0                                               3/3     Running      0             21h     10.32.2.32    ncn-w001   <none>           <none>
services          keycloak-postgres-1                                               3/3     Running      0             21h     10.32.4.244   ncn-w002   <none>           <none>
services          keycloak-postgres-2                                               3/3     Running      0             21h     10.32.3.219   ncn-w003   <none>           <none>
spire             cray-spire-postgres-0                                             3/3     Running      0             21h     10.32.3.15    ncn-w003   <none>           <none>
spire             cray-spire-postgres-1                                             3/3     Running      0             21h     10.32.2.25    ncn-w001   <none>           <none>
spire             cray-spire-postgres-2                                             3/3     Running      0             21h     10.32.4.106   ncn-w002   <none>           <none>

--- FAILURE ---

- Errors and Warnings are printed below -
ERROR: state of each cray-nls-postgres member is not 'running'
ERROR: state of each cfs-ara-postgres member is not 'running'
ERROR: state of each cray-console-data-postgres member is not 'running'
ERROR: state of each cray-dhcp-kea-postgres member is not 'running'
ERROR: state of each cray-dns-powerdns-postgres member is not 'running'
ERROR: state of each cray-sls-postgres member is not 'running'
ERROR: state of each cray-smd-postgres member is not 'running'
ERROR: state of each gitea-vcs-postgres member is not 'running'
ERROR: state of each keycloak-postgres member is not 'running'
ERROR: state of each cray-spire-postgres member is not 'running'
ncn-m001:/opt/cray/platform-utils #
```

With this diff, the test is fixed ...
```
 ncn-m001:/opt/cray/platform-utils # diff ncnPostgresHealthChecks-orig.sh  ncnPostgresHealthChecks.sh
157c157
<         num_running_patronictl=$(kubectl -n $c_ns -c postgres exec $leader -- patronictl list 2>/dev/null | grep running | wc -l)
---
>         num_running_patronictl=$(kubectl -n $c_ns -c postgres exec $leader -- patronictl list 2>/dev/null | grep -E "running|streaming" | wc -l)
164,165c164,165
<             echo "--- ERROR --- state of each $c_name member $m is not 'running'"
<             failureMsg="${failureMsg}\nERROR: state of each $c_name member is not 'running'"
---
>             echo "--- ERROR --- state of each $c_name member $m is not 'running' or 'streaming'"
>             failureMsg="${failureMsg}\nERROR: state of each $c_name member is not 'running' or 'streaming'"
ncn-m001:/opt/cray/platform-utils #
```

New output ...
```
ncn-m001:/opt/cray/platform-utils # ./ncnPostgresHealthChecks.sh
             +++++ NCN Postgres Health Checks +++++
=== Can Be Executed on any ncn worker or master node. ===
=== Executing on ncn-m001, Fri Sep 12 01:00:54 PM UTC 2025 ===

=== Postgresql Operator Version ===
artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1

=== List of Postgresql Clusters Using Operator ===
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            15        3      2Gi                                     18h   Running
services    cfs-ara-postgres             cfs-ara             15        3      50Gi     100m          100Mi            18h   Running
services    cray-console-data-postgres   cray-console-data   15        3      2Gi      100m          256Mi            18h   Running
services    cray-dhcp-kea-postgres       cray-dhcp-kea       15        3      10Gi     500m          1Gi              18h   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   15        3      10Gi     100m          100Mi            18h   Running
services    cray-sls-postgres            cray-sls            15        3      1Gi      100m          128Mi            18h   Running
services    cray-smd-postgres            cray-smd            15        3      100Gi    100m          100Mi            18h   Running
services    gitea-vcs-postgres           gitea-vcs           15        3      50Gi     100m          256Mi            17h   Running
services    keycloak-postgres            keycloak            15        3      10Gi                                    18h   Running
spire       cray-spire-postgres          cray-spire          15        3      60Gi     500m          1Gi              17h   Running

=== Look at patronictl list info for each cluster, determine and attach to leader of each cluster ===
=== Report status of postgres pods in cluster ===
-----------------------------------------------------------------------------------------------------

=== Looking at patronictl list info for the cray-nls-postgres cluster with leader pod: cray-nls-postgres-0 ===

--- patronictl, version , list for argo leader pod cray-nls-postgres-0 ---
+ Cluster: cray-nls-postgres (7548906233256181824) -------+----+-----------+
| Member              | Host        | Role    | State     | TL | Lag in MB |
+---------------------+-------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.32.2.251 | Leader  | running   |  1 |           |
| cray-nls-postgres-1 | 10.32.4.165 | Replica | streaming |  1 |         0 |
| cray-nls-postgres-2 | 10.32.3.174 | Replica | streaming |  1 |         0 |
+---------------------+-------------+---------+-----------+----+-----------+
NAMESPACE         NAME                                                              READY   STATUS       RESTARTS      AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo              cray-nls-postgres-0                                               3/3     Running      0             18h     10.32.2.251   ncn-w001   <none>           <none>
argo              cray-nls-postgres-1                                               3/3     Running      0             18h     10.32.4.165   ncn-w002   <none>           <none>
argo              cray-nls-postgres-2                                               3/3     Running      0             18h     10.32.3.174   ncn-w003   <none>           <none>

--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
<snip>
=== kubectl get pods -A -o wide | grep "NAME\|postgres-" | grep -v "operator\|Completed\|pooler" ===

NAMESPACE         NAME                                                              READY   STATUS       RESTARTS      AGE     IP            NODE       NOMINATED NODE   READINESS GATES
argo              cray-nls-postgres-0                                               3/3     Running      0             18h     10.32.2.251   ncn-w001   <none>           <none>
argo              cray-nls-postgres-1                                               3/3     Running      0             18h     10.32.4.165   ncn-w002   <none>           <none>
argo              cray-nls-postgres-2                                               3/3     Running      0             18h     10.32.3.174   ncn-w003   <none>           <none>
services          cfs-ara-postgres-0                                                3/3     Running      0             18h     10.32.3.26    ncn-w003   <none>           <none>
services          cfs-ara-postgres-1                                                3/3     Running      0             18h     10.32.4.231   ncn-w002   <none>           <none>
services          cfs-ara-postgres-2                                                3/3     Running      0             18h     10.32.2.213   ncn-w001   <none>           <none>
services          cray-console-data-postgres-0                                      3/3     Running      0             18h     10.32.3.111   ncn-w003   <none>           <none>
services          cray-console-data-postgres-1                                      3/3     Running      0             18h     10.32.2.184   ncn-w001   <none>           <none>
services          cray-console-data-postgres-2                                      3/3     Running      0             18h     10.32.4.135   ncn-w002   <none>           <none>
services          cray-dhcp-kea-postgres-0                                          3/3     Running      0             18h     10.32.2.160   ncn-w001   <none>           <none>
services          cray-dhcp-kea-postgres-1                                          3/3     Running      0             18h     10.32.3.162   ncn-w003   <none>           <none>
services          cray-dhcp-kea-postgres-2                                          3/3     Running      0             18h     10.32.4.72    ncn-w002   <none>           <none>
services          cray-dns-powerdns-postgres-0                                      3/3     Running      0             18h     10.32.2.12    ncn-w001   <none>           <none>
services          cray-dns-powerdns-postgres-1                                      3/3     Running      0             18h     10.32.4.194   ncn-w002   <none>           <none>
services          cray-dns-powerdns-postgres-2                                      3/3     Running      0             18h     10.32.3.210   ncn-w003   <none>           <none>
services          cray-sls-postgres-0                                               3/3     Running      0             18h     10.32.2.108   ncn-w001   <none>           <none>
services          cray-sls-postgres-1                                               3/3     Running      0             18h     10.32.4.31    ncn-w002   <none>           <none>
services          cray-sls-postgres-2                                               3/3     Running      0             18h     10.32.3.149   ncn-w003   <none>           <none>
services          cray-smd-postgres-0                                               3/3     Running      0             18h     10.32.2.155   ncn-w001   <none>           <none>
services          cray-smd-postgres-1                                               3/3     Running      0             18h     10.32.4.233   ncn-w002   <none>           <none>
services          cray-smd-postgres-2                                               3/3     Running      0             18h     10.32.3.124   ncn-w003   <none>           <none>
services          gitea-vcs-postgres-0                                              3/3     Running      0             17h     10.32.4.193   ncn-w002   <none>           <none>
services          gitea-vcs-postgres-1                                              3/3     Running      0             17h     10.32.2.115   ncn-w001   <none>           <none>
services          gitea-vcs-postgres-2                                              3/3     Running      0             17h     10.32.3.107   ncn-w003   <none>           <none>
services          keycloak-postgres-0                                               3/3     Running      0             18h     10.32.2.32    ncn-w001   <none>           <none>
services          keycloak-postgres-1                                               3/3     Running      0             18h     10.32.4.244   ncn-w002   <none>           <none>
services          keycloak-postgres-2                                               3/3     Running      0             18h     10.32.3.219   ncn-w003   <none>           <none>
spire             cray-spire-postgres-0                                             3/3     Running      0             17h     10.32.3.15    ncn-w003   <none>           <none>
spire             cray-spire-postgres-1                                             3/3     Running      0             17h     10.32.2.25    ncn-w001   <none>           <none>
spire             cray-spire-postgres-2                                             3/3     Running      0             17h     10.32.4.106   ncn-w002   <none>           <none>

PASSED. All postgresql checks passed.
ncn-m001:/opt/cray/platform-utils #
```

On upgrade, the docs-csm `postgres-reinit.sh` script is broken because the Replica pods are in `streaming` state rather than `running` state.  This is fixed with this diff ...
```
ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade/util # diff postgres-reinit-orig.sh postgres-reinit.sh
121c121
<       while kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -v -m 1 "running"; do
---
>       while kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -Ev -m 1 "running|streaming"; do
123,124c123,124
<         failed_instance=$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -v -m 1 "running" | awk '{print $2}')
<         echo "Reinit ${failed_instance} not in running state: attempt ${reinit_count}/${reinit_max}..."
---
>         failed_instance=$(kubectl exec -i ${leader} -n ${pg_ns} -- patronictl list | grep "${pg_cluster}-" | grep -Ev -m 1 "running|streaming" | awk '{print $2}')
>         echo "Reinit ${failed_instance} not in running or streaming state: attempt ${reinit_count}/${reinit_max}..."
ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade/util #
```

Output without fix ...
```
ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade/util # ./postgres-reinit-orig.sh
Postgres-operator pod running
Working on cray-nls-postgres in namespace argo ...
cray-nls-postgres-0   3/3   Running   0     17h
INFO: found a running pod cray-nls-postgres-0
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
INFO: found the leader pod cray-nls-postgres-1
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
Reinit cray-nls-postgres-0 not in running state: attempt 1/5...
+ Cluster: cray-nls-postgres (7548905379163471941) ------+----+-----------+
| Member              | Host       | Role    | State     | TL | Lag in MB |
+---------------------+------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
| cray-nls-postgres-2 | 10.44.0.1  | Replica | streaming |  3 |         0 |
+---------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-nls-postgres-0? [y/N]: Success: reinitialize for member cray-nls-postgres-0
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
Reinit cray-nls-postgres-0 not in running state: attempt 2/5...
+ Cluster: cray-nls-postgres (7548905379163471941) ------+----+-----------+
| Member              | Host       | Role    | State     | TL | Lag in MB |
+---------------------+------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
| cray-nls-postgres-2 | 10.44.0.1  | Replica | streaming |  3 |         0 |
+---------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-nls-postgres-0? [y/N]: Success: reinitialize for member cray-nls-postgres-0
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
Reinit cray-nls-postgres-0 not in running state: attempt 3/5...
+ Cluster: cray-nls-postgres (7548905379163471941) ------+----+-----------+
| Member              | Host       | Role    | State     | TL | Lag in MB |
+---------------------+------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
| cray-nls-postgres-2 | 10.44.0.1  | Replica | streaming |  3 |         0 |
+---------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-nls-postgres-0? [y/N]: Success: reinitialize for member cray-nls-postgres-0
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
Reinit cray-nls-postgres-0 not in running state: attempt 4/5...
+ Cluster: cray-nls-postgres (7548905379163471941) ------+----+-----------+
| Member              | Host       | Role    | State     | TL | Lag in MB |
+---------------------+------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
| cray-nls-postgres-2 | 10.44.0.1  | Replica | streaming |  3 |         0 |
+---------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-nls-postgres-0? [y/N]: Success: reinitialize for member cray-nls-postgres-0
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
Reinit cray-nls-postgres-0 not in running state: attempt 5/5...
+ Cluster: cray-nls-postgres (7548905379163471941) ------+----+-----------+
| Member              | Host       | Role    | State     | TL | Lag in MB |
+---------------------+------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.40.0.13 | Replica | streaming |  3 |         0 |
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
| cray-nls-postgres-2 | 10.44.0.1  | Replica | streaming |  3 |         0 |
+---------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-nls-postgres-0? [y/N]: Success: reinitialize for member cray-nls-postgres-0
Reinit count reached 5. Breaking loop.
Working on cfs-ara-postgres in namespace services ...
cfs-ara-postgres-0             3/3   Running   0     17h
INFO: found a running pod cfs-ara-postgres-0
| cfs-ara-postgres-2 | 10.40.0.49 | Leader  | running   |  3 |           |
INFO: found the leader pod cfs-ara-postgres-2
| cfs-ara-postgres-0 | 10.44.0.20 | Replica | streaming |  3 |         0 |
Reinit cfs-ara-postgres-0 not in running state: attempt 1/5...
+ Cluster: cfs-ara-postgres (7548909221021970505) ------+----+-----------+
| Member             | Host       | Role    | State     | TL | Lag in MB |
+--------------------+------------+---------+-----------+----+-----------+
| cfs-ara-postgres-0 | 10.44.0.20 | Replica | streaming |  3 |         0 |
| cfs-ara-postgres-1 | 10.32.0.17 | Replica | streaming |  3 |         0 |
| cfs-ara-postgres-2 | 10.40.0.49 | Leader  | running   |  3 |           |
+--------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cfs-ara-postgres-0? [y/N]: Success: reinitialize for member cfs-ara-postgres-0
| cfs-ara-postgres-0 | 10.44.0.20 | Replica | streaming |  3 |         0 |
Reinit cfs-ara-postgres-0 not in running state: attempt 2/5...
<snip>
Reinit cray-dhcp-kea-postgres-1 not in running state: attempt 4/5...
+ Cluster: cray-dhcp-kea-postgres (7548905728801439817) ------+----+-----------+
| Member                   | Host       | Role    | State     | TL | Lag in MB |
+--------------------------+------------+---------+-----------+----+-----------+
| cray-dhcp-kea-postgres-0 | 10.40.0.40 | Leader  | running   |  3 |           |
| cray-dhcp-kea-postgres-1 | 10.32.0.40 | Replica | streaming |  3 |         0 |
| cray-dhcp-kea-postgres-2 | 10.44.0.50 | Replica | streaming |  3 |         0 |
+--------------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-dhcp-kea-postgres-1? [y/N]: Success: reinitialize for member cray-dhcp-kea-postgres-1
| cray-dhcp-kea-postgres-1 | 10.32.0.40 | Replica | streaming |  3 |         0 |
Reinit cray-dhcp-kea-postgres-1 not in running state: attempt 5/5...
+ Cluster: cray-dhcp-kea-postgres (7548905728801439817) ------+----+-----------+
| Member                   | Host       | Role    | State     | TL | Lag in MB |
+--------------------------+------------+---------+-----------+----+-----------+
| cray-dhcp-kea-postgres-0 | 10.40.0.40 | Leader  | running   |  3 |           |
| cray-dhcp-kea-postgres-1 | 10.32.0.40 | Replica | streaming |  3 |         0 |
| cray-dhcp-kea-postgres-2 | 10.44.0.50 | Replica | streaming |  3 |         0 |
+--------------------------+------------+---------+-----------+----+-----------+
Are you sure you want to reinitialize members cray-dhcp-kea-postgres-1? [y/N]: Success: reinitialize for member cray-dhcp-kea-postgres-1
Reinit count reached 5. Breaking loop.
Working on cray-dns-powerdns-postgres in namespace services ...
cray-dns-powerdns-postgres-0   3/3   Running   0     43m
INFO: found a running pod cray-dns-powerdns-postgres-0
WARNING: No running leader is found for cray-dns-powerdns-postgres in services. Rollout restart it and sleep for 60 seconds, attempt 1/3)...
statefulset.apps/cray-dns-powerdns-postgres restarted
WARNING: No running leader is found for cray-dns-powerdns-postgres in services. Rollout restart it and sleep for 60 seconds, attempt 2/3)...
Error from server (NotFound): statefulsets.apps "cray-dns-powerdns-postgres" not found
ncn-m001:/usr/share/doc/csm/upgrade/scripts/upgrade/util #
```

Output with fix ...
```
ncn-m001:~ # /usr/share/doc/csm/upgrade/scripts/upgrade/util/postgres-reinit.sh
Postgres-operator pod running
Working on cray-nls-postgres in namespace argo ...
cray-nls-postgres-0   3/3   Running   0     17h
INFO: found a running pod cray-nls-postgres-0
| cray-nls-postgres-1 | 10.32.0.5  | Leader  | running   |  3 |           |
INFO: found the leader pod cray-nls-postgres-1
Working on cfs-ara-postgres in namespace services ...
cfs-ara-postgres-0             3/3   Running   0     17h
INFO: found a running pod cfs-ara-postgres-0
| cfs-ara-postgres-2 | 10.40.0.49 | Leader  | running   |  3 |           |
INFO: found the leader pod cfs-ara-postgres-2
Working on cray-console-data-postgres in namespace services ...
cray-console-data-postgres-0   3/3   Running   0     17h
INFO: found a running pod cray-console-data-postgres-0
| cray-console-data-postgres-2 | 10.40.0.47 | Leader  | running   |  3 |           |
INFO: found the leader pod cray-console-data-postgres-2
Working on cray-dhcp-kea-postgres in namespace services ...
cray-dhcp-kea-postgres-0       3/3   Running   0     17h
INFO: found a running pod cray-dhcp-kea-postgres-0
| cray-dhcp-kea-postgres-0 | 10.40.0.40 | Leader  | running   |  3 |           |
INFO: found the leader pod cray-dhcp-kea-postgres-0
Working on cray-dns-powerdns-postgres in namespace services ...
cray-dns-powerdns-postgres-0   3/3   Running   0     60m
INFO: found a running pod cray-dns-powerdns-postgres-0
WARNING: No running leader is found for cray-dns-powerdns-postgres in services. Rollout restart it and sleep for 60 seconds, attempt 1/3)...
statefulset.apps/cray-dns-powerdns-postgres restarted
WARNING: No running leader is found for cray-dns-powerdns-postgres in services. Rollout restart it and sleep for 60 seconds, attempt 2/3)...
statefulset.apps/cray-dns-powerdns-postgres restarted
WARNING: No running leader is found for cray-dns-powerdns-postgres in services. Rollout restart it and sleep for 60 seconds, attempt 3/3)...
statefulset.apps/cray-dns-powerdns-postgres restarted
ERROR: Unable to recover cray-dns-powerdns-postgres in services automatically. You may have to re-install the chart.
ncn-m001:~ #
```