### PR TITLE
CASMPET-7669: Wrap cray-postgres-operator-psp rolebinding in conditional

### DIFF
--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.10.3
+version: 1.10.4
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:

--- a/kubernetes/cray-postgres-operator/templates/rbac.yaml
+++ b/kubernetes/cray-postgres-operator/templates/rbac.yaml
@@ -21,6 +21,7 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 # RoleBinding for PSP with cray-postgres-operator ServiceAccount in services namespace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -35,6 +36,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "cray-postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -26,7 +26,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.24.17
+    tag: 1.32.2
 
 postgres-operator:
   image:


### PR DESCRIPTION
## Summary and Scope
CASMPET-7669: Wrap cray-postgres-operator-psp rolebinding in conditional to be created if Kubernetes capability PodSecurityPolicy exists
  * Update docker-kubectl to 1.32.2

## Issues and Related PRs

* Resolves [CASMPET-7669](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7669)

## Testing
Tested on vShasta system beau.

Ran remove_psp.sh script to clean up left over PSP rolebindings before upgrading to cray-postgres-operator 1.10.4-20250915213258+9a0648c chart.
```
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "argo-psp" deleted
rolebinding.rbac.authorization.k8s.io "cert-manager-psp" deleted
rolebinding.rbac.authorization.k8s.io "istio-system-psp" deleted
rolebinding.rbac.authorization.k8s.io "loftsman-psp" deleted
rolebinding.rbac.authorization.k8s.io "operators-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-console-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "cray-node-discovery" deleted
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted
rolebinding.rbac.authorization.k8s.io "services-default-psp" deleted
rolebinding.rbac.authorization.k8s.io "sonar-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-provisioner-psp" deleted
rolebinding.rbac.authorization.k8s.io "spire-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "tpm-intermediate-psp" deleted
rolebinding.rbac.authorization.k8s.io "vault-psp" deleted
```

After script is executed, the cray-postgres-operator-psp rolebinding no longer exists.
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
PSP_ONLY_SA=

delete_sa(): NOP
pit:~/studenym #
```

Successfully upgraded helm chart.
```
pit:~/studenym/cray-postgres-operator # helm upgrade -n services cray-postgres-operator cray-postgres-operator-1.10.4-20250915213258+9a0648c.tgz
Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Mon Sep 15 22:11:43 2025
NAMESPACE: services
STATUS: deployed
REVISION: 6
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
pit:~/studenym/cray-postgres-operator #
pit:~/studenym # helm history -n services cray-postgres-operator
REVISION	UPDATED                 	STATUS    	CHART                                               	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:18 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Install complete
2       	Tue Sep  9 18:55:38 2025	superseded	cray-postgres-operator-1.10.4                       	1.10.1     	Upgrade complete
3       	Tue Sep  9 19:19:40 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Rollback to 1
4       	Wed Sep 10 16:10:25 2025	superseded	cray-postgres-operator-1.10.4-20250910151804+8b00e0a	1.10.1     	Upgrade complete
5       	Wed Sep 10 17:49:25 2025	superseded	cray-postgres-operator-1.10.3                       	1.10.1     	Rollback to 1
6       	Mon Sep 15 22:11:43 2025	deployed  	cray-postgres-operator-1.10.4-20250915213258+9a0648c	1.10.1     	Upgrade complete
pit:~/studenym #
```

cray-postgres-operator-psp rolebinding was not created when the new chart was deployed.
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
PSP_ONLY_SA=

delete_sa(): NOP
pit:~/studenym #
```

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

