### PR TITLE
CASMPET-7480: Need to upgrade postgres-operator along with logical-backup

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -33,6 +33,7 @@ jobs:
     uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
     with:
       lint-charts: ${{ github.event_name == 'pull_request' }}
+      target-branch: ${{ github.event.pull_request.base.ref || 'master' }}
       ct-config: |
         chart-dirs:
           - kubernetes

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright 2020, 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-postgres-operator/Chart.lock
+++ b/kubernetes/cray-postgres-operator/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgres-operator
   repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
   version: 1.14.0
-digest: sha256:65b56e1d61f37876eb59bc6ce77a16887344629c33e047bc216c78b2d92ae974
-generated: "2025-02-06T11:40:14.864051-06:00"
+digest: sha256:d2162f0c673d5c121ab134a442f64167e8ffef5ceca24884094c715eb56411bd
+generated: "2025-11-25T04:03:12.851532494Z"

--- a/kubernetes/cray-postgres-operator/Chart.lock
+++ b/kubernetes/cray-postgres-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgres-operator
   repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
-  version: 1.15.0
+  version: 1.14.0
 digest: sha256:65b56e1d61f37876eb59bc6ce77a16887344629c33e047bc216c78b2d92ae974
 generated: "2025-02-06T11:40:14.864051-06:00"

--- a/kubernetes/cray-postgres-operator/Chart.lock
+++ b/kubernetes/cray-postgres-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgres-operator
   repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
-  version: 1.10.1
+  version: 1.15.0
 digest: sha256:65b56e1d61f37876eb59bc6ce77a16887344629c33e047bc216c78b2d92ae974
 generated: "2025-02-06T11:40:14.864051-06:00"

--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.10.4
+version: 1.15.0
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -32,21 +32,21 @@ sources:
   - https://github.com/zalando/postgres-operator
 dependencies:
   - name: postgres-operator
-    version: 1.10.1
+    version: 1.15.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 maintainers:
   - name: kimjensen-hpe
-appVersion: "1.10.1"  # the postgres-operator dependent chart version
+appVersion: "1.15.0"  # the postgres-operator dependent chart version
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: postgres-operator
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.10.1
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.15.0
     - name: postgres-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
     - name: spilo-14
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     - name: logical-backup
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.15.0
     - name: pgbouncer
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-27

--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
     version: 1.14.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 maintainers:
-  - name: kimjensen-hpe
+  - name: keshav-06-hpe
 appVersion: "1.14.0"  # the postgres-operator dependent chart version
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-postgres-operator/Chart.yaml
+++ b/kubernetes/cray-postgres-operator/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.15.0
+version: 1.14.0
 name: cray-postgres-operator
 description: Cray-specific parent chart of github.com/zalando/postgres-operator
 keywords:
@@ -32,21 +32,21 @@ sources:
   - https://github.com/zalando/postgres-operator
 dependencies:
   - name: postgres-operator
-    version: 1.15.0
+    version: 1.14.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 maintainers:
   - name: kimjensen-hpe
-appVersion: "1.15.0"  # the postgres-operator dependent chart version
+appVersion: "1.14.0"  # the postgres-operator dependent chart version
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/images: |
     - name: postgres-operator
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.15.0
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator:v1.14.0
     - name: postgres-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
     - name: spilo-14
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.0-p1
     - name: logical-backup
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.15.0
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.14.0
     - name: pgbouncer
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-27

--- a/kubernetes/cray-postgres-operator/crds/postgres-operator-crds-1.10.1.yaml
+++ b/kubernetes/cray-postgres-operator/crds/postgres-operator-crds-1.10.1.yaml
@@ -515,7 +515,7 @@ spec:
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
+                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.15.0"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/kubernetes/cray-postgres-operator/crds/postgres-operator-crds-1.14.0.yaml
+++ b/kubernetes/cray-postgres-operator/crds/postgres-operator-crds-1.14.0.yaml
@@ -515,7 +515,7 @@ spec:
                     pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.15.0"
+                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.14.0"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -32,7 +32,7 @@ postgres-operator:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator
-    tag: v1.10.1
+    tag: v1.15.0
     pullPolicy: "IfNotPresent"
 
   podAnnotations:
@@ -112,7 +112,7 @@ postgres-operator:
   nodeSelector: {}
 
   configLogicalBackup:
-    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.10.1"
+    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.15.0"
     logical_backup_job_prefix: logical-backup-
     logical_backup_provider: s3
     logical_backup_s3_bucket: postgres-backup

--- a/kubernetes/cray-postgres-operator/values.yaml
+++ b/kubernetes/cray-postgres-operator/values.yaml
@@ -32,7 +32,7 @@ postgres-operator:
   image:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/registry.opensource.zalan.do/acid/postgres-operator
-    tag: v1.15.0
+    tag: v1.14.0
     pullPolicy: "IfNotPresent"
 
   podAnnotations:
@@ -112,7 +112,7 @@ postgres-operator:
   nodeSelector: {}
 
   configLogicalBackup:
-    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.15.0"
+    logical_backup_docker_image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/logical-backup:v1.14.0"
     logical_backup_job_prefix: logical-backup-
     logical_backup_provider: s3
     logical_backup_s3_bucket: postgres-backup


### PR DESCRIPTION
## Summary and Scope

This PR is raised to upgrade `postgres-operator:v1.10.1` to `postgres-operator:v1.14.0`. We are doing this upgrade as the logical-backup is also upgraded from `logical-backup:v1.10.1` to `logical-backup:v1.14.0`.


## Issues and Related PRs

* Resolves [CASMPET-7480](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7480)
* Change will also be needed in `container-image`
* Related PR: [container-images/pull/726](https://github.com/Cray-HPE/container-images/pull/726)

## Testing

### Tested on:

  * `Mug`

### Test description:

With the latest unstable images created on `Mug`, the pods and jobs are running properly with the latest images.


## Risks and Mitigations

_None_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

